### PR TITLE
Rule links

### DIFF
--- a/app/parse-link.tsx
+++ b/app/parse-link.tsx
@@ -34,6 +34,13 @@ const parseLink = (
 ): string | JSX.element => {
   let linkText: string = exampleText || obj.text;
 
+  // Regex
+  const regexSection = /section\s+(\d)/gim;
+  // Include extra characters to avoid creating links on erroneous numbers, ex: 2011
+  const regexChapter = /\s+(\d{3}[\s,.;])/gim;
+  const regexRule = /(\d{3})\.(\d+)/gim;
+  const regexSubrule = /(\d{3})\.(\d+)([a-z]+)/gim;
+
   const findMatches = (
     regex: RegExp,
     text: string | JSX.Element,
@@ -45,10 +52,16 @@ const parseLink = (
       ? exampleText.match(regex)
       : obj.text.match(regex);
 
-    // Remove /section\s+/ from matchArray
-    matchArray.forEach((value, i) => {
-      if (value.includes("section")) {
-        matchArray[i] = value.replace(/section\s+/, "");
+    // Remove extra characters from matchArray
+    matchArray.forEach((ruleNumber, i) => {
+      // Remove /section\s+/ from matchArray
+      if (ruleNumber.includes("section")) {
+        matchArray[i] = ruleNumber.replace(/section\s+/, "");
+      }
+
+      // Remove extra characters from chapter ruleNumbers
+      if (/\s|\.|,|;|-|:/.test(ruleNumber) && (regexChapter).test(ruleNumber)) {
+        matchArray[i] = ruleNumber.replaceAll(/\s|\.|,|;|-|:/g, "");
       }
     });
 
@@ -59,13 +72,7 @@ const parseLink = (
     return updatedText;
   };
 
-  // Regex
-  const regexSection = /section\s+(\d)/gim;
-  const regexChapter = /(\d{3})/gim;
-  const regexRule = /(\d{3}).(\d+)/gim;
-  const regexSubrule = /(\d{3}).(\d+)([a-z]+)/gim;
-
-  // Test if a chapter, rule, and subrule are referenced in text
+  // Test if subrule, rule, chapter, and section numbers appear in text
   if (regexSubrule.test(linkText)) {
     linkText = findMatches(regexSubrule, linkText);
   }

--- a/app/parse-link.tsx
+++ b/app/parse-link.tsx
@@ -1,0 +1,74 @@
+import Link from "next/link";
+import reactStringReplace from "react-string-replace";
+import { Rule, Subrule, RouterValues } from "./types";
+
+const element = (
+  updatedText: string,
+  ruleNumber: string,
+  routerValues: RouterValues,
+  obj: Rule | Subrule,
+): string => reactStringReplace(updatedText, ruleNumber, (match, i) => (
+    <span
+      key={
+        obj.type === "rule"
+          ? `${obj.ruleNumber}-${ruleNumber}-${i}`
+          : `${obj.ruleNumber}${obj.subruleLetter}-${ruleNumber}-${i}`
+      }
+    >
+      <Link
+        href={"/rules/[routerValues.year]/[routerValues.version]"}
+        as={`/rules/${routerValues.year}/${routerValues.version}#${ruleNumber}`}
+        scroll={false}
+      >
+        <a>
+          <span>{match}</span>
+        </a>
+      </Link>
+    </span>
+));
+
+const parseLink = (
+  obj: Rule | Subrule,
+  routerValues: RouterValues,
+  exampleText = "",
+): string | JSX.element => {
+  let linkText: string = exampleText || obj.text;
+
+  const findMatches = (
+    regex: RegExp,
+    text: string | JSX.Element,
+  ): string | JSX.Element => {
+    let updatedText = text;
+
+    // Get string matches
+    const matchArray: string[] = (exampleText)
+      ? exampleText.match(regex)
+      : obj.text.match(regex);
+
+    // Cycle through text for each rule number string, replacing number with jsx
+    matchArray.forEach((ruleNumber) => {
+      updatedText = element(updatedText, ruleNumber, routerValues, obj);
+    });
+    return updatedText;
+  };
+
+  // Regex
+  const regexChapter = /(\d{3})/gim;
+  const regexRule = /(\d{3}).(\d+)/gim;
+  const regexSubrule = /(\d{3}).(\d+)([a-z]+)/gim;
+
+  // Test if a chapter, rule, and subrule are referenced in text
+  if (regexSubrule.test(linkText)) {
+    linkText = findMatches(regexSubrule, linkText);
+  }
+  if (regexRule.test(linkText)) {
+    linkText = findMatches(regexRule, linkText);
+  }
+  if (regexChapter.test(linkText)) {
+    linkText = findMatches(regexChapter, linkText);
+  }
+  // Return original string or string with links
+  return linkText;
+};
+
+export default parseLink;

--- a/app/parse-link.tsx
+++ b/app/parse-link.tsx
@@ -45,6 +45,13 @@ const parseLink = (
       ? exampleText.match(regex)
       : obj.text.match(regex);
 
+    // Remove /section\s+/ from matchArray
+    matchArray.forEach((value, i) => {
+      if (value.includes("section")) {
+        matchArray[i] = value.replace(/section\s+/, "");
+      }
+    });
+
     // Cycle through text for each rule number string, replacing number with jsx
     matchArray.forEach((ruleNumber) => {
       updatedText = element(updatedText, ruleNumber, routerValues, obj);
@@ -53,6 +60,7 @@ const parseLink = (
   };
 
   // Regex
+  const regexSection = /section\s+(\d)/gim;
   const regexChapter = /(\d{3})/gim;
   const regexRule = /(\d{3}).(\d+)/gim;
   const regexSubrule = /(\d{3}).(\d+)([a-z]+)/gim;
@@ -66,6 +74,9 @@ const parseLink = (
   }
   if (regexChapter.test(linkText)) {
     linkText = findMatches(regexChapter, linkText);
+  }
+  if (regexSection.test(linkText)) {
+    linkText = findMatches(regexSection, linkText);
   }
   // Return original string or string with links
   return linkText;

--- a/app/rules-parse.ts
+++ b/app/rules-parse.ts
@@ -22,7 +22,7 @@ const rulesParse = async (rawText: string, i = 0): Promise<void | Nodes> => {
       parser.addRule(sectionRegex, (match, section, txt) => {
         const sectionNumber = Number(section);
 
-        return { type: "section", txt, sectionNumber };
+        return { type: "section", text: txt, sectionNumber };
       });
       parser.addRule(chapterRegex, (match, chapter, txt) => {
         const sectionNumber = Number(chapter[0]);

--- a/app/rules-parse.ts
+++ b/app/rules-parse.ts
@@ -1,6 +1,6 @@
 import { Parser } from "simple-text-parser";
 import parseExamples from "./parse-examples";
-import { Nodes } from './types';
+import { Nodes } from "./types";
 
 const rulesParse = async (rawText: string, i = 0): Promise<void | Nodes> => {
   // Retry 3 times
@@ -19,24 +19,29 @@ const rulesParse = async (rawText: string, i = 0): Promise<void | Nodes> => {
       const subruleRegex = /^(\d{3}).(\d+)([a-z]+)\s+([\s\S]+?)[\r\n][\r\n][\r\n][\r\n]/gm;
 
       // Add rules
-      parser.addRule(sectionRegex, (match, section, text) => {
+      parser.addRule(sectionRegex, (match, section, txt) => {
         const sectionNumber = Number(section);
 
-        return { type: "section", text, sectionNumber };
+        return { type: "section", txt, sectionNumber };
       });
-      parser.addRule(chapterRegex, (match, chapter, text) => {
+      parser.addRule(chapterRegex, (match, chapter, txt) => {
         const sectionNumber = Number(chapter[0]);
         const chapterNumber = Number(chapter);
 
-        return { type: "chapter", text, sectionNumber, chapterNumber };
+        return {
+          type: "chapter",
+          text: txt,
+          sectionNumber,
+          chapterNumber,
+        };
       });
-      parser.addRule(ruleRegex, (match, chapter, rule, text) => {
+      parser.addRule(ruleRegex, (match, chapter, rule, txt) => {
         const sectionNumber = Number(chapter[0]);
         const chapterNumber = Number(chapter);
         const ruleNumber = Number(rule);
 
         // Handle text that has examples
-        const textParse = parseExamples(text);
+        const textParse = parseExamples(txt);
 
         return {
           type: "rule",
@@ -49,13 +54,13 @@ const rulesParse = async (rawText: string, i = 0): Promise<void | Nodes> => {
       });
       parser.addRule(
         subruleRegex,
-        (match, chapter, rule, subruleLetter, text) => {
+        (match, chapter, rule, subruleLetter, txt) => {
           const sectionNumber = Number(chapter[2]);
           const chapterNumber = Number(chapter);
           const ruleNumber = Number(rule);
 
           // Handle text that has examples
-          const textParse = parseExamples(text);
+          const textParse = parseExamples(txt);
 
           return {
             type: "subrule",
@@ -79,7 +84,6 @@ const rulesParse = async (rawText: string, i = 0): Promise<void | Nodes> => {
 
       let val = i;
       val += 1;
-      console.log(`Retry count: ${i}`);
       rulesParse(rawText, val);
     }
   }

--- a/app/types.ts
+++ b/app/types.ts
@@ -33,3 +33,8 @@ export interface Subrule {
 export interface Nodes {
   nodes: (Section | Chapter | Rule | Subrule)[];
 }
+
+export interface RouterValues {
+  year: string;
+  version: string;
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "17.0.2",
     "react-bootstrap": "^1.6.1",
     "react-dom": "17.0.2",
+    "react-string-replace": "^0.4.4",
     "sass": "^1.35.1",
     "simple-text-parser": "^2.1.1",
     "typescript": "^4.3.4"

--- a/pages/components/modules/ChapterList.tsx
+++ b/pages/components/modules/ChapterList.tsx
@@ -5,6 +5,7 @@ import { Chapter, Rule, Subrule } from "../../../app/types";
 import styles from "../../../styles/ChapterList.module.scss";
 
 interface Props {
+  section: Section;
   chapters: Chapter[];
   rules: Rule[];
   subrules: Subrule[];
@@ -12,14 +13,19 @@ interface Props {
 
 const ChapterList = (props: Props): JSX.Element => {
   const {
+    section,
     chapters,
     rules,
     subrules,
   } = props;
 
+  const chapterSubset = chapters.filter(
+    (chapter) => chapter.sectionNumber === section.sectionNumber,
+  );
+
   return (
     <div>
-      {chapters.map((chapter, index) => (
+      {chapterSubset.map((chapter, index) => (
         <div key={`chapter${chapter.chapterNumber}-${index}`}>
           <ChapterTitle chapter={chapter} toc={0} />
           <RuleGroup chapter={chapter} rules={rules} subrules={subrules} />

--- a/pages/components/modules/ChapterList.tsx
+++ b/pages/components/modules/ChapterList.tsx
@@ -11,13 +11,17 @@ interface Props {
 }
 
 const ChapterList = (props: Props): JSX.Element => {
-  const { chapters, rules, subrules } = props;
+  const {
+    chapters,
+    rules,
+    subrules,
+  } = props;
 
   return (
     <div>
       {chapters.map((chapter, index) => (
-        <div key={index}>
-          <ChapterTitle chapter={chapter} toc={0}/>
+        <div key={`chapter${chapter.chapterNumber}-${index}`}>
+          <ChapterTitle chapter={chapter} toc={0} />
           <RuleGroup chapter={chapter} rules={rules} subrules={subrules} />
         </div>
       ))}

--- a/pages/components/modules/ChapterTitle.tsx
+++ b/pages/components/modules/ChapterTitle.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { Chapter, Section } from "../../../app/types";
+import { Chapter } from "../../../app/types";
 import styles from "../../../styles/ChapterTitle.module.scss";
 
 interface Props {

--- a/pages/components/modules/ChapterTitle.tsx
+++ b/pages/components/modules/ChapterTitle.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { Chapter } from "../../../app/types";
+import { Chapter, Section } from "../../../app/types";
 import styles from "../../../styles/ChapterTitle.module.scss";
 
 interface Props {
@@ -17,22 +17,29 @@ const ChapterTitle = (props: Props): JSX.Element => {
   const { version, year }: string = router.query;
   const pathname = `/${router.pathname.split("/")[1]}/${year}/${version}/`;
 
+  // If toc, return toc chapter title. Else rule list chapter title
   return (
     <div>
-      {toc
-        ? (<li key={`${key}${chapter.chapterNumber}`} className={styles.chapterList}>
+      {toc ? (
+        <li
+          key={`${key}${chapter.chapterNumber}`}
+          className={styles.chapterList}
+        >
           <Link
-            href={"/rules/[year]/[version]"} as={`${pathname}#${chapter.chapterNumber}`}
-            // href={`${pathname}#${chapter.chapterNumber.toString()}`}
+            href={"/rules/[year]/[version]"}
+            as={`${pathname}#${chapter.chapterNumber}`}
             scroll={false}
           >
             <a>
-              <span className={styles.chapterNum}>{chapter.chapterNumber}.</span>
+              <span className={styles.chapterNum}>
+                {chapter.chapterNumber}.
+              </span>
               <span className={styles.chapterTextToc}>{chapter.text}</span>
             </a>
           </Link>
-        </li>)
-        : (<div>
+        </li>
+      ) : (
+        <div>
           <section id={`${chapter.chapterNumber}`}>
             <span
               key={`${key}${chapter.chapterNumber}`}
@@ -41,8 +48,8 @@ const ChapterTitle = (props: Props): JSX.Element => {
               {chapter.chapterNumber}. &nbsp; {chapter.text}
             </span>
           </section>
-        </div>)
-      }
+        </div>
+      )}
     </div>
   );
 };

--- a/pages/components/modules/Example.tsx
+++ b/pages/components/modules/Example.tsx
@@ -1,5 +1,7 @@
 import React from "react";
-import { Rule, Subrule } from "../../../app/types";
+import { useRouter } from "next/router";
+import parseLink from "../../../app/parse-link";
+import { Rule, Subrule, RouterValues } from "../../../app/types";
 import styles from "../../../styles/Example.module.scss";
 
 interface Props {
@@ -11,6 +13,12 @@ const Example = (props: Props): JSX.Element => {
   const { rule, subrule } = props;
   const data: Rule | Subrule = rule || subrule;
 
+  const router = useRouter();
+  const routerValues: RouterValues = {
+    year: router.query.year,
+    version: router.query.version,
+  };
+
   return (
     <div>
       {data.example.map(
@@ -19,7 +27,7 @@ const Example = (props: Props): JSX.Element => {
             key={rule ? `rule-e${index}` : `subrule-e${index}`}
             className={`${styles.example} list-group-item`}
           >
-            {example}
+            {parseLink(data, routerValues, example)}
           </li>
         ),
       )}

--- a/pages/components/modules/RuleList.tsx
+++ b/pages/components/modules/RuleList.tsx
@@ -1,7 +1,9 @@
 import React from "react";
+import { useRouter } from "next/router";
 import SubruleGroup from "./SubruleGroup";
 import Example from "./Example";
-import { Rule, Subrule } from "../../../app/types";
+import parseLink from "../../../app/parse-link";
+import { Rule, Subrule, RouterValues } from "../../../app/types";
 import styles from "../../../styles/RuleList.module.scss";
 
 interface Props {
@@ -12,6 +14,12 @@ interface Props {
 const RuleList = (props: Props): JSX.Element => {
   const { ruleSubset, subrules } = props;
 
+  const router = useRouter();
+  const routerValues: RouterValues = {
+    year: router.query.year,
+    version: router.query.version,
+  };
+
   return (
     <div>
       {ruleSubset.map((rule, index) => (
@@ -21,7 +29,7 @@ const RuleList = (props: Props): JSX.Element => {
               key={`r${rule.ruleNumber}`}
               className={`${styles.ruleText} list-group-item`}
             >
-              {rule.chapterNumber}.{rule.ruleNumber} &nbsp; {rule.text}
+              {rule.chapterNumber}.{rule.ruleNumber} &nbsp; {parseLink(rule, routerValues)}
             </li>
           </section>
           <Example rule={rule} />

--- a/pages/components/modules/RuleList.tsx
+++ b/pages/components/modules/RuleList.tsx
@@ -16,12 +16,14 @@ const RuleList = (props: Props): JSX.Element => {
     <div>
       {ruleSubset.map((rule, index) => (
         <div key={`d-${index}`}>
-          <li
-            key={`r${rule.ruleNumber}`}
-            className={`${styles.ruleText} list-group-item`}
-          >
-            {rule.chapterNumber}.{rule.ruleNumber} &nbsp; {rule.text}
-          </li>
+          <section id={`${rule.chapterNumber}.${rule.ruleNumber}`}>
+            <li
+              key={`r${rule.ruleNumber}`}
+              className={`${styles.ruleText} list-group-item`}
+            >
+              {rule.chapterNumber}.{rule.ruleNumber} &nbsp; {rule.text}
+            </li>
+          </section>
           <Example rule={rule} />
           <SubruleGroup rule={rule} subrules={subrules} />
         </div>

--- a/pages/components/modules/SectionList.tsx
+++ b/pages/components/modules/SectionList.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import ChapterList from "./ChapterList";
+import {
+  Section,
+  Chapter,
+  Rule,
+  Subrule,
+} from "../../../app/types";
+import styles from "../../../styles/SectionList.module.scss";
+
+interface Props {
+  sections: Section[];
+  chapters: Chapter[];
+  rules: Rule[];
+  subrules: Subrule[];
+}
+
+const SectionList = (props: Props): JSX.Element => {
+  const {
+    sections,
+    chapters,
+    rules,
+    subrules,
+  } = props;
+
+  return (
+    <div>
+      {sections.map((section, index) => (
+        <div key={`${section.sectionNumber}-${index}`}>
+        <section id={`${section.sectionNumber}`}>
+          <span>
+            {section.sectionNumber}. &nbsp; {section.text}
+          </span>
+        </section>
+          <ChapterList chapters={chapters} rules={rules} subrules={subrules} />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default SectionList;

--- a/pages/components/modules/SectionList.tsx
+++ b/pages/components/modules/SectionList.tsx
@@ -32,7 +32,7 @@ const SectionList = (props: Props): JSX.Element => {
             {section.sectionNumber}. &nbsp; {section.text}
           </span>
         </section>
-          <ChapterList chapters={chapters} rules={rules} subrules={subrules} />
+          <ChapterList section={section} chapters={chapters} rules={rules} subrules={subrules} />
         </div>
       ))}
     </div>

--- a/pages/components/modules/SubruleList.tsx
+++ b/pages/components/modules/SubruleList.tsx
@@ -14,13 +14,17 @@ const SubruleList = (props: Props): JSX.Element => {
     <div>
       {subruleSubset.map((subrule, index) => (
         <div key={`dv${index}`}>
-          <li
-            key={`subr-${index}`}
-            className={`${styles.subruleText} list-group-item`}
+          <section
+            id={`${subrule.chapterNumber}.${subrule.ruleNumber}${subrule.subruleLetter}`}
           >
-            {subrule.chapterNumber}.{subrule.ruleNumber}
-            {subrule.subruleLetter} &nbsp; {subrule.text}
-          </li>
+            <li
+              key={`subr-${index}`}
+              className={`${styles.subruleText} list-group-item`}
+            >
+              {subrule.chapterNumber}.{subrule.ruleNumber}
+              {subrule.subruleLetter} &nbsp; {subrule.text}
+            </li>
+          </section>
           <Example subrule={subrule} />
         </div>
       ))}

--- a/pages/components/modules/SubruleList.tsx
+++ b/pages/components/modules/SubruleList.tsx
@@ -1,6 +1,8 @@
 import React from "react";
+import { useRouter } from "next/router";
 import Example from "./Example";
-import { Subrule } from "../../../app/types";
+import parseLink from "../../../app/parse-link";
+import { Subrule, RouterValues } from "../../../app/types";
 import styles from "../../../styles/SubruleList.module.scss";
 
 interface Props {
@@ -9,6 +11,12 @@ interface Props {
 
 const SubruleList = (props: Props): JSX.Element => {
   const { subruleSubset } = props;
+
+  const router = useRouter();
+  const routerValues: RouterValues = {
+    year: router.query.year,
+    version: router.query.version,
+  };
 
   return (
     <div>
@@ -22,7 +30,7 @@ const SubruleList = (props: Props): JSX.Element => {
               className={`${styles.subruleText} list-group-item`}
             >
               {subrule.chapterNumber}.{subrule.ruleNumber}
-              {subrule.subruleLetter} &nbsp; {subrule.text}
+              {subrule.subruleLetter} &nbsp; {parseLink(subrule, routerValues)}
             </li>
           </section>
           <Example subrule={subrule} />

--- a/pages/components/modules/TocChapterList.tsx
+++ b/pages/components/modules/TocChapterList.tsx
@@ -5,16 +5,20 @@ import styles from "../../../styles/TocChapterList.module.scss";
 
 interface Props {
   chapters: Chapter[];
+  sectionNumber: number;
+  toc: number;
 }
 
 const TocChapterList = (props: Props): JSX.Element => {
-  const { chapters } = props;
+  const { chapters, sectionNumber, toc } = props;
+
+  const chapterSubset = chapters.filter((chapter) => chapter.sectionNumber === sectionNumber);
 
   return (
     <div className={styles.tocChapters}>
-      {chapters.map((chapter, index) => (
+      {chapterSubset.map((chapter, index) => (
         <ul className={"list-group"} key={`titles-${index}`}>
-          <ChapterTitle chapter={chapter} toc={1} />
+          <ChapterTitle chapter={chapter} toc={toc} />
         </ul>
       ))}
     </div>

--- a/pages/rules/[year]/[version].tsx
+++ b/pages/rules/[year]/[version].tsx
@@ -4,9 +4,9 @@ import Spinner from "react-bootstrap/Spinner";
 import rulesParse from "../../../app/rules-parse";
 import formValidation from "../../../app/form-validation";
 import TocSections from "../../components/modules/TocSections";
-import ChapterList from "../../components/modules/ChapterList";
+import SectionList from "../../components/modules/SectionList";
 import Form from "../../components/modules/Form";
-import { Nodes } from "../../../app/types";
+import { Nodes, RouterValues } from "../../../app/types";
 import styles from "../../../styles/[version].module.scss";
 
 interface Props {
@@ -47,9 +47,12 @@ const RuleSetPage = (props: Props): JSX.Element => {
   const router = useRouter();
 
   // Get currentUrl for Form
-  const currentYear = router.query.year;
-  const currentVersion = router.query.version;
-  const currentUrl = `https://media.wizards.com/${currentYear}/downloads/MagicCompRules%${currentVersion}.txt`;
+  const routerValues: RouterValues = {
+    year: router.query.year,
+    version: router.query.version,
+  };
+
+  const currentUrl = `https://media.wizards.com/${routerValues.year}/downloads/MagicCompRules%${routerValues.version}.txt`;
 
   // Form validation Prop. Validate different ruleset
   const validateUrl = async (url: string): Promise<number> => {
@@ -64,7 +67,7 @@ const RuleSetPage = (props: Props): JSX.Element => {
     const year: number = reYear.test(url) ? url.match(reYear)[0] : 0;
 
     // That ruleset is already displayed
-    if (currentVersion === version && currentYear === year) {
+    if (routerValues.version === version && routerValues.year === year) {
       return 3;
     }
 
@@ -134,7 +137,8 @@ const RuleSetPage = (props: Props): JSX.Element => {
         </div>
         <div>
           <div className={styles.chapterList}>
-            <ChapterList
+            <SectionList
+              sections={sections}
               chapters={chapters}
               rules={rules}
               subrules={subrules}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2028,7 +2028,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@^4.17.13, lodash@^4.17.21:
+lodash@^4.17.13, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -2724,6 +2724,13 @@ react-refresh@0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
+
+react-string-replace@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/react-string-replace/-/react-string-replace-0.4.4.tgz#24006fbe0db573d5be583133df38b1a735cb4225"
+  integrity sha512-FAMkhxmDpCsGTwTZg7p/2v+/GTmxAp73so3fbSvlAcBBX36ujiGRNEaM/1u+jiYQrArhns+7eE92g2pi5E5FUA==
+  dependencies:
+    lodash "^4.17.4"
 
 react-transition-group@^4.4.1:
   version "4.4.2"


### PR DESCRIPTION
- Fixed issue with displaying all chapters per section in ToC
- Added Section titles to rule list to link to them 
- Added linking to section, chapter, rule, and subrule titles in the rule list.
    - When a chapter number is referenced, such as "300" or "rule 300", a link is added to the number to anchor link to the 300 section tag