### PR TITLE
Typescript fixes

### DIFF
--- a/app/form-validation.ts
+++ b/app/form-validation.ts
@@ -3,10 +3,10 @@ const dev = process.env.NODE_ENV !== "production";
 const formValidation = async (url: string, version: number, year: number): Promise<number> => {
   // Remove host
   const noHost: string = url.replace(/http(s|):\/\//i, "");
-  const split: string = noHost.replace(version, "").split("/");
+  const split: string[] = noHost.replace(`${version}`, "").split("/");
 
   // If it is an invalid ruleset url
-  const re1 = /media[.]wizards[.]com/i;
+  const re1 = /media\.wizards\.com/i;
   const path1: string = re1.test(split[0]) ? split[0].match(re1)[0] : "";
 
   const re2 = /downloads/i;
@@ -20,13 +20,16 @@ const formValidation = async (url: string, version: number, year: number): Promi
     return 2;
   }
 
+  const versionString = `${version}`;
+  const yearString = `${year}`;
+
   const result = await (dev
     ? fetch("/api/ruleset-validation",
       {
         headers:
           {
-            version,
-            year,
+            version: versionString,
+            year: yearString,
           },
       })
     : fetch(url)

--- a/app/form-validation.ts
+++ b/app/form-validation.ts
@@ -1,6 +1,6 @@
 const dev = process.env.NODE_ENV !== "production";
 
-const formValidation = async (url: string, version: number, year: number): Promise<number> => {
+const formValidation = async (url: string, version: string, year: string): Promise<number> => {
   // Remove host
   const noHost: string = url.replace(/http(s|):\/\//i, "");
   const split: string[] = noHost.replace(`${version}`, "").split("/");

--- a/app/parse-examples.ts
+++ b/app/parse-examples.ts
@@ -1,4 +1,4 @@
-const parseExamples = (text: string): string[] => {
+const parseExamples = (text: string): (string | string[])[] => {
   // Split example text
   const splitText: string[] = text.split("\r\n");
 
@@ -10,8 +10,13 @@ const parseExamples = (text: string): string[] => {
     ? splitText.map((example) => example)
     : [];
 
+  // Result
+  const result: (string | string[])[] = [];
+  result.push(mainText);
+  result.push(exampleText)
+
   // Return
-  return [mainText, exampleText];
+  return result;
 };
 
 export default parseExamples;

--- a/app/parse-examples.ts
+++ b/app/parse-examples.ts
@@ -1,4 +1,6 @@
-const parseExamples = (text: string): (string | string[])[] => {
+import { ParseExample } from "./types";
+
+const parseExamples = (text: string): ParseExample => {
   // Split example text
   const splitText: string[] = text.split("\r\n");
 
@@ -6,17 +8,15 @@ const parseExamples = (text: string): (string | string[])[] => {
   const mainText: string = splitText.splice(0, 1)[0];
 
   // Create an array of example text
-  const exampleText: string[] = splitText
+  const exampleTextArray: string[] = splitText
     ? splitText.map((example) => example)
     : [];
 
-  // Result
-  const result: (string | string[])[] = [];
-  result.push(mainText);
-  result.push(exampleText)
-
-  // Return
-  return result;
+  // Return ParseExample object
+  return {
+    mainText,
+    exampleTextArray,
+  }
 };
 
 export default parseExamples;

--- a/app/parse-link.tsx
+++ b/app/parse-link.tsx
@@ -1,49 +1,54 @@
+import { ReactNodeArray } from "react";
 import Link from "next/link";
 import reactStringReplace from "react-string-replace";
-import { Rule, Subrule, RouterValues } from "./types";
+import { ParseLinkArgs, ReplaceRuleNumbers } from "./types";
 
-const element = (
-  updatedText: string,
-  ruleNumber: string,
-  routerValues: RouterValues,
-  obj: Rule | Subrule,
-  onLinkClick: (chapterNumber: number) => number,
-): string => reactStringReplace(updatedText, ruleNumber, (match, i) => {
-  // Convert section digits to the first chapter value of a section
-  const chapterValue = (/\d{3}/.test(ruleNumber))
-    ? Number(ruleNumber.match(/\d{3}/)[0])
-    : Number(ruleNumber) * 100;
-
-  return (
-    <span
-      key={
-        obj.type === "rule"
-          ? `${obj.ruleNumber}-${ruleNumber}-${i}`
-          : `${obj.ruleNumber}${obj.subruleLetter}-${ruleNumber}-${i}`
-      }
-    >
-      <Link
-        href={"/rules/[routerValues.year]/[routerValues.version]"}
-        as={`/rules/${routerValues.year}/${routerValues.version}#${chapterValue}`}
-        scroll={false}
+const replaceRuleNumbers = (args: ReplaceRuleNumbers): ReactNodeArray => {
+  const { text, ruleNumberArray, routerValues, onLinkClick, rule, subrule } = args;
+  let updatedText: ReactNodeArray;
+  ruleNumberArray.forEach((ruleNumber, index) => {
+    const chapterValue = (/\d{3}/.test(ruleNumber))
+      ? Number(ruleNumber.match(/\d{3}/)[0])
+      : Number(ruleNumber) * 100;
+      
+    updatedText = reactStringReplace(
+      ((index === 0) ? text : updatedText),
+      ruleNumber,
+      (match: string, i: number) => (
+      <span
+        key={
+          rule
+            ? `${rule.ruleNumber}-${ruleNumber}-${i}`
+            : `${subrule.ruleNumber}${subrule.subruleLetter}-${ruleNumber}-${i}`
+        }
       >
-        <a>
-          <span onClick={() => onLinkClick(chapterValue, "rules")}>
-            {match}
-          </span>
-        </a>
-      </Link>
-    </span>
-  );
-});
+        <Link
+          href={"/rules/[routerValues.year]/[routerValues.version]"}
+          as={`/rules/${routerValues.year}/${routerValues.version}#${chapterValue}`}
+          scroll={false}
+        >
+          <a>
+            <span onClick={() => onLinkClick(chapterValue, "rules")}>
+              {match}
+            </span>
+          </a>
+        </Link>
+      </span>
+    ));
+  });
+  return updatedText;
+};
 
-const parseLink = (
-  obj: Rule | Subrule,
-  routerValues: RouterValues,
-  onLinkClick: (chapterNumber: number) => number,
-  exampleText = "",
-): string | JSX.element => {
-  let linkText: string = exampleText || obj.text;
+const parseLink = (args: ParseLinkArgs): string | ReactNodeArray => {
+  const { routerValues, onLinkClick, example, rule, subrule } = args;
+  let linkText: string;
+  if (example) {
+    linkText = example;
+  } else if (rule) {
+    linkText = rule.text;
+  } else if (subrule) {
+    linkText = subrule.text;
+  }
 
   // Regex
   const regexSection = /section\s+(\d)/gim;
@@ -54,46 +59,61 @@ const parseLink = (
   const regexes = [regexSubrule, regexRule, regexChapter, regexSection];
 
   const findMatches = (
-    regex: RegExp,
-    text: string | JSX.Element,
-  ): string | JSX.Element => {
-    let updatedText = text;
+    regexArray: RegExp[],
+    text: string,
+  ): string | ReactNodeArray => {
+    const matchArray: RegExpMatchArray[] = [];
+    let ruleNumberArray: string[];
 
-    // Get string matches
-    const matchArray: string[] = (exampleText)
-      ? exampleText.match(regex)
-      : obj.text.match(regex);
+    regexArray.forEach((regex) => {
+      // Find all matches for a particular regex
+      if (typeof(text) === "string") {
+        matchArray.push(text.match(regex));
+      } else {
+        console.log(text)
+      }
+    })
+
+    // Push all matched ruleNumber strings to ruleNumberArray
+    ruleNumberArray = matchArray.flat();
 
     // Remove extra characters from matchArray
-    matchArray.forEach((ruleNumber, i) => {
+    ruleNumberArray.forEach((ruleNumber, i) => {
       // Remove /section\s+/ from matchArray
       if (ruleNumber.includes("section")) {
-        matchArray[i] = ruleNumber.replace(/section\s+/, "");
+        ruleNumberArray[i] = ruleNumber.replace(/section\s+/, "");
       }
 
       // TODO: Prevent invalid chapter values like 999
       // Remove extra characters from chapter ruleNumbers
       if (/\s|\.|,|;|-|:/.test(ruleNumber) && (regexChapter).test(ruleNumber)) {
-        matchArray[i] = ruleNumber.replace(/\s|\.|,|;|-|:/g, "");
+        ruleNumberArray[i] = ruleNumber.replace(/\s|\.|,|;|-|:/g, "");
       }
     });
 
-    // Cycle through text for each rule number string, replacing number with jsx
-    matchArray.forEach((ruleNumber) => {
-      updatedText = element(updatedText, ruleNumber, routerValues, obj, onLinkClick);
-    });
-    return updatedText;
+    // return updatedText;
+    const args: ReplaceRuleNumbers = (rule) 
+      ? {text, ruleNumberArray, routerValues, onLinkClick, rule}
+      : {text, ruleNumberArray, routerValues, onLinkClick, subrule}
+    return replaceRuleNumbers(args);
   };
 
   // Test if subrule, rule, chapter, and section numbers appear in text
+  const regexArray: RegExp[] = [];
   regexes.forEach((regex) => {
     if (regex.test(linkText)) {
-      linkText = findMatches(regex, linkText);
+      regexArray.push(regex);
+      // linkText = findMatches(regex, linkText);
     }
   });
+  
+  // If there are no linkable ruleNumbers, use linkText, else process matches
+  const result: string | ReactNodeArray = (!regexArray.length)
+    ? linkText
+    : findMatches(regexArray, linkText);
 
   // Return original string or string with links
-  return linkText;
+  return result;
 };
 
 export default parseLink;

--- a/app/parse-link.tsx
+++ b/app/parse-link.tsx
@@ -8,7 +8,13 @@ const element = (
   routerValues: RouterValues,
   obj: Rule | Subrule,
   onLinkClick: (chapterNumber: number) => number,
-): string => reactStringReplace(updatedText, ruleNumber, (match, i) => (
+): string => reactStringReplace(updatedText, ruleNumber, (match, i) => {
+  // Convert section digits to the first chapter value of a section
+  const chapterValue = (/\d{3}/.test(ruleNumber))
+    ? Number(ruleNumber.match(/\d{3}/)[0])
+    : Number(ruleNumber) * 100;
+
+  return (
     <span
       key={
         obj.type === "rule"
@@ -18,19 +24,18 @@ const element = (
     >
       <Link
         href={"/rules/[routerValues.year]/[routerValues.version]"}
-        as={`/rules/${routerValues.year}/${routerValues.version}#${ruleNumber}`}
+        as={`/rules/${routerValues.year}/${routerValues.version}#${chapterValue}`}
         scroll={false}
       >
         <a>
-          <span onClick={() => onLinkClick((/\d{3}/.test(ruleNumber))
-            ? Number(ruleNumber.match(/\d{3}/)[0])
-            : Number(ruleNumber))}>
+          <span onClick={() => onLinkClick(chapterValue, "rules")}>
             {match}
           </span>
         </a>
       </Link>
     </span>
-));
+  );
+});
 
 const parseLink = (
   obj: Rule | Subrule,
@@ -43,7 +48,7 @@ const parseLink = (
   // Regex
   const regexSection = /section\s+(\d)/gim;
   // Include extra characters to avoid creating links on erroneous numbers, ex: 2011
-  const regexChapter = /\s+(\d{3}[\s,.;])/gim;
+  const regexChapter = /\s+(\d{3})[\s,.;]/gim;
   const regexRule = /(\d{3})\.(\d+)/gim;
   const regexSubrule = /(\d{3})\.(\d+)([a-z]+)/gim;
   const regexes = [regexSubrule, regexRule, regexChapter, regexSection];
@@ -66,7 +71,7 @@ const parseLink = (
         matchArray[i] = ruleNumber.replace(/section\s+/, "");
       }
 
-      // TODO: 121.8, 723 link is incorrect
+      // TODO: Prevent invalid chapter values like 999
       // Remove extra characters from chapter ruleNumbers
       if (/\s|\.|,|;|-|:/.test(ruleNumber) && (regexChapter).test(ruleNumber)) {
         matchArray[i] = ruleNumber.replace(/\s|\.|,|;|-|:/g, "");

--- a/app/parse-link.tsx
+++ b/app/parse-link.tsx
@@ -65,16 +65,13 @@ const parseLink = (args: ParseLinkArgs): string | ReactNodeArray => {
     const matchArray: RegExpMatchArray[] = [];
     let ruleNumberArray: string[];
 
+    // Push all matched ruleNumber strings to matchArray
     regexArray.forEach((regex) => {
       // Find all matches for a particular regex
-      if (typeof(text) === "string") {
-        matchArray.push(text.match(regex));
-      } else {
-        console.log(text)
-      }
+      matchArray.push(text.match(regex));
     })
 
-    // Push all matched ruleNumber strings to ruleNumberArray
+    // Flatten matchArray
     ruleNumberArray = matchArray.flat();
 
     // Remove extra characters from matchArray
@@ -91,7 +88,6 @@ const parseLink = (args: ParseLinkArgs): string | ReactNodeArray => {
       }
     });
 
-    // return updatedText;
     const args: ReplaceRuleNumbers = (rule) 
       ? {text, ruleNumberArray, routerValues, onLinkClick, rule}
       : {text, ruleNumberArray, routerValues, onLinkClick, subrule}
@@ -103,7 +99,6 @@ const parseLink = (args: ParseLinkArgs): string | ReactNodeArray => {
   regexes.forEach((regex) => {
     if (regex.test(linkText)) {
       regexArray.push(regex);
-      // linkText = findMatches(regex, linkText);
     }
   });
   

--- a/app/parse-link.tsx
+++ b/app/parse-link.tsx
@@ -7,6 +7,7 @@ const element = (
   ruleNumber: string,
   routerValues: RouterValues,
   obj: Rule | Subrule,
+  onLinkClick: (chapterNumber: number) => number,
 ): string => reactStringReplace(updatedText, ruleNumber, (match, i) => (
     <span
       key={
@@ -21,7 +22,11 @@ const element = (
         scroll={false}
       >
         <a>
-          <span>{match}</span>
+          <span onClick={() => onLinkClick((/\d{3}/.test(ruleNumber))
+            ? Number(ruleNumber.match(/\d{3}/)[0])
+            : Number(ruleNumber))}>
+            {match}
+          </span>
         </a>
       </Link>
     </span>
@@ -30,6 +35,7 @@ const element = (
 const parseLink = (
   obj: Rule | Subrule,
   routerValues: RouterValues,
+  onLinkClick: (chapterNumber: number) => number,
   exampleText = "",
 ): string | JSX.element => {
   let linkText: string = exampleText || obj.text;
@@ -60,6 +66,7 @@ const parseLink = (
         matchArray[i] = ruleNumber.replace(/section\s+/, "");
       }
 
+      // TODO: 121.8, 723 link is incorrect
       // Remove extra characters from chapter ruleNumbers
       if (/\s|\.|,|;|-|:/.test(ruleNumber) && (regexChapter).test(ruleNumber)) {
         matchArray[i] = ruleNumber.replace(/\s|\.|,|;|-|:/g, "");
@@ -68,7 +75,7 @@ const parseLink = (
 
     // Cycle through text for each rule number string, replacing number with jsx
     matchArray.forEach((ruleNumber) => {
-      updatedText = element(updatedText, ruleNumber, routerValues, obj);
+      updatedText = element(updatedText, ruleNumber, routerValues, obj, onLinkClick);
     });
     return updatedText;
   };

--- a/app/rules-parse.ts
+++ b/app/rules-parse.ts
@@ -1,8 +1,9 @@
-import { Parser } from "simple-text-parser";
+import { Parser, Node } from "simple-text-parser";
+import sortBy from "lodash/sortBy";
 import parseExamples from "./parse-examples";
-import { Nodes, ParseExample } from "./types";
+import { ParseExample, RulesParse, Section, Chapter, Rule, Subrule } from "./types";
 
-const rulesParse = async (rawText: string, i = 0): Promise<void | Nodes> => {
+const rulesParse = async (rawText: string, i = 0): Promise<RulesParse> => {
   // Retry 3 times
   if (i < 4) {
     try {
@@ -77,8 +78,25 @@ const rulesParse = async (rawText: string, i = 0): Promise<void | Nodes> => {
       // Remove all not matched nodes
       const tree = parser.toTree(text).filter((node) => node.type !== "text");
 
+      // Filter nodes
+      const sectionNodes: Node[] = sortBy(
+        tree.filter((node) => node.type === "section"),
+        ["sectionNumber"],
+      );
+      const chapterNodes: Node[] = sortBy(
+        tree.filter((node) => node.type === "chapter"),
+        ["sectionNumber", "chapterNumber"],
+      );
+      const rules: Node[] = tree.filter((node) => node.type === "rule");
+      const subrules: Node[] = tree.filter((node) => node.type === "subrule");
+
       // Return
-      return tree;
+      return {
+        sections: (sectionNodes as any) as Section[],
+        chapters: (chapterNodes as any) as Chapter[],
+        rules: (rules as any) as Rule[],
+        subrules: (subrules as any) as Subrule[],
+      }
     } catch (err) {
       console.error(err);
 

--- a/app/rules-parse.ts
+++ b/app/rules-parse.ts
@@ -41,7 +41,7 @@ const rulesParse = async (rawText: string, i = 0): Promise<void | Nodes> => {
         const ruleNumber = Number(rule);
 
         // Handle text that has examples
-        const textParse = parseExamples(txt);
+        const textParse: string[] = parseExamples(txt);
 
         return {
           type: "rule",
@@ -60,7 +60,7 @@ const rulesParse = async (rawText: string, i = 0): Promise<void | Nodes> => {
           const ruleNumber = Number(rule);
 
           // Handle text that has examples
-          const textParse = parseExamples(txt);
+          const textParse: string[] = parseExamples(txt);
 
           return {
             type: "subrule",

--- a/app/rules-parse.ts
+++ b/app/rules-parse.ts
@@ -1,6 +1,6 @@
 import { Parser } from "simple-text-parser";
 import parseExamples from "./parse-examples";
-import { Nodes } from "./types";
+import { Nodes, ParseExample } from "./types";
 
 const rulesParse = async (rawText: string, i = 0): Promise<void | Nodes> => {
   // Retry 3 times
@@ -41,15 +41,15 @@ const rulesParse = async (rawText: string, i = 0): Promise<void | Nodes> => {
         const ruleNumber = Number(rule);
 
         // Handle text that has examples
-        const textParse: string[] = parseExamples(txt);
+        const textParse: ParseExample = parseExamples(txt);
 
         return {
           type: "rule",
-          text: textParse[0],
+          text: (textParse) ? textParse.mainText : "",
           sectionNumber,
           chapterNumber,
           ruleNumber,
-          example: textParse[1],
+          example: (textParse) ? textParse.exampleTextArray : "",
         };
       });
       parser.addRule(
@@ -60,16 +60,16 @@ const rulesParse = async (rawText: string, i = 0): Promise<void | Nodes> => {
           const ruleNumber = Number(rule);
 
           // Handle text that has examples
-          const textParse: string[] = parseExamples(txt);
+          const textParse: ParseExample = parseExamples(txt);
 
           return {
             type: "subrule",
-            text: textParse[0],
+            text: (textParse) ? textParse.mainText : "",
             sectionNumber,
             chapterNumber,
             ruleNumber,
             subruleLetter,
-            example: textParse[1],
+            example: (textParse) ? textParse.exampleTextArray : "",
           };
         },
       );

--- a/app/types.ts
+++ b/app/types.ts
@@ -46,3 +46,8 @@ export interface ChapterValues {
   init: number;
   source: string;
 }
+
+export interface ErrorData {
+  reason: string;
+  value: number;
+}

--- a/app/types.ts
+++ b/app/types.ts
@@ -30,10 +30,6 @@ export interface Subrule {
   example: string[];
 }
 
-export interface Nodes {
-  nodes: (Section | Chapter | Rule | Subrule)[];
-}
-
 export interface RouterValues {
   year: string;
   version: string;
@@ -73,4 +69,27 @@ export interface ReplaceRuleNumbers {
 export interface ParseExample {
   mainText: string;
   exampleTextArray: string[];
+}
+
+export interface DynamicProps {
+  nodes: RulesParse;
+  effectiveDate: string;
+}
+
+export interface GetStaticPropsResult {
+  props: DynamicProps | {};
+  revalidate?: number;
+  notFound?: boolean;
+}
+
+export interface ValidateChapter {
+  nodes: RulesParse;
+  validChapter: Chapter | undefined | boolean;
+}
+
+export interface RulesParse {
+  sections: Section[],
+  chapters: Chapter[],
+  rules: Rule[],
+  subrules: Subrule[],
 }

--- a/app/types.ts
+++ b/app/types.ts
@@ -52,3 +52,20 @@ export interface ErrorData {
   reason: string;
   value: number;
 }
+
+export interface ParseLinkArgs {
+  routerValues: RouterValues;
+  onLinkClick: (chapterNumber: number, dataSource: string) => void;
+  example?: string;
+  rule?: Rule;
+  subrule?: Subrule;
+}
+
+export interface ReplaceRuleNumbers {
+  text: string;
+  ruleNumberArray: string[];
+  routerValues: RouterValues;
+  onLinkClick: (chapterNumber: number, dataSource: string) => void;
+  rule?: Rule;
+  subrule?: Subrule;
+}

--- a/app/types.ts
+++ b/app/types.ts
@@ -69,3 +69,8 @@ export interface ReplaceRuleNumbers {
   rule?: Rule;
   subrule?: Subrule;
 }
+
+export interface ParseExample {
+  mainText: string;
+  exampleTextArray: string[];
+}

--- a/app/types.ts
+++ b/app/types.ts
@@ -45,6 +45,7 @@ export interface ChapterValues {
   anchorValue: number;
   init: number;
   source: string;
+  propValue: number;
 }
 
 export interface ErrorData {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "typescript": "^4.3.4"
   },
   "devDependencies": {
+    "@types/lodash.sortby": "^4.7.6",
     "@types/react": "^17.0.11",
     "@typescript-eslint/eslint-plugin": "^4.28.1",
     "@typescript-eslint/parser": "^4.28.1",

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,11 +1,7 @@
 import styles from "../styles/Custom404.module.scss";
+import { ErrorData } from "../app/types";
 
-interface Props {
-  reason: string;
-  value: number;
-}
-
-const Custom404 = (props: Props): JSX.Element => {
+const Custom404 = (props: ErrorData): JSX.Element => {
   const { reason, value } = props;
 
   return (

--- a/pages/components/modules/ChapterList.tsx
+++ b/pages/components/modules/ChapterList.tsx
@@ -8,6 +8,7 @@ interface Props {
   rules?: Rule[];
   subrules?: Subrule[];
   elRef: HTMLDivElement | null;
+  onLinkClick: (chapterNumber: number) => number;
 }
 
 const ChapterList = (props: Props): JSX.Element => {
@@ -17,6 +18,7 @@ const ChapterList = (props: Props): JSX.Element => {
     rules,
     subrules,
     elRef,
+    onLinkClick,
   } = props;
 
   let chapterSubset: Chapter[];
@@ -37,6 +39,7 @@ const ChapterList = (props: Props): JSX.Element => {
             rules={rules}
             subrules={subrules}
             elRef={elRef}
+            onLinkClick={onLinkClick}
           />
         </div>
       ))}

--- a/pages/components/modules/ChapterList.tsx
+++ b/pages/components/modules/ChapterList.tsx
@@ -1,4 +1,4 @@
-import { RefObject } from "react";
+import { LegacyRef, RefObject } from "react";
 import RuleGroup from "./RuleGroup";
 import { Section, Chapter, Rule, Subrule } from "../../../app/types";
 import styles from "../../../styles/ChapterList.module.scss";
@@ -8,7 +8,7 @@ interface Props {
   chapters: Chapter[];
   rules?: Rule[];
   subrules?: Subrule[];
-  elRef: (node: RefObject<HTMLDivElement>) => void | null;
+  elRef: (node: LegacyRef<HTMLDivElement>) => void | null;
   onLinkClick: (chapterNumber: number, dataSource: string) => void;
 }
 

--- a/pages/components/modules/ChapterList.tsx
+++ b/pages/components/modules/ChapterList.tsx
@@ -1,5 +1,5 @@
 import RuleGroup from "./RuleGroup";
-import { Chapter, Rule, Subrule } from "../../../app/types";
+import { Section, Chapter, Rule, Subrule } from "../../../app/types";
 import styles from "../../../styles/ChapterList.module.scss";
 
 interface Props {

--- a/pages/components/modules/ChapterList.tsx
+++ b/pages/components/modules/ChapterList.tsx
@@ -1,3 +1,4 @@
+import { RefObject } from "react";
 import RuleGroup from "./RuleGroup";
 import { Section, Chapter, Rule, Subrule } from "../../../app/types";
 import styles from "../../../styles/ChapterList.module.scss";
@@ -7,8 +8,8 @@ interface Props {
   chapters: Chapter[];
   rules?: Rule[];
   subrules?: Subrule[];
-  elRef: HTMLDivElement | null;
-  onLinkClick: (chapterNumber: number) => number;
+  elRef: (node: RefObject<HTMLDivElement>) => void | null;
+  onLinkClick: (chapterNumber: number, dataSource: string) => void;
 }
 
 const ChapterList = (props: Props): JSX.Element => {

--- a/pages/components/modules/ChapterTitle.tsx
+++ b/pages/components/modules/ChapterTitle.tsx
@@ -1,3 +1,4 @@
+import { RefObject } from "react";
 import Link from "next/link";
 import { Spinner } from "react-bootstrap";
 import { useRouter, NextRouter } from "next/router";
@@ -7,8 +8,8 @@ import styles from "../../../styles/ChapterTitle.module.scss";
 interface Props {
   chapter: Chapter;
   toc: number;
-  onLinkClick?: (chapterNumber: number) => number;
-  tocTitleRef?: HTMLElement | null;
+  onLinkClick?: (chapterNumber: number, dataSource: string) => void;
+  tocTitleRef?: (node: RefObject<HTMLDivElement>) => void | null;
   effectiveDate?: string;
   sections?: Section[];
 }

--- a/pages/components/modules/ChapterTitle.tsx
+++ b/pages/components/modules/ChapterTitle.tsx
@@ -90,13 +90,13 @@ const ChapterTitle = (props: Props): JSX.Element => {
               <a>
                 <span
                   className={styles.chapterNum}
-                  onClick={() => onLinkClick(chapterObj.chapterNumber)}
+                  onClick={() => onLinkClick(chapterObj.chapterNumber, "toc")}
                 >
                   {chapterObj.chapterNumber}.
                 </span>
                 <span
                   className={styles.chapterTextToc}
-                  onClick={() => onLinkClick(chapterObj.chapterNumber)}
+                  onClick={() => onLinkClick(chapterObj.chapterNumber, "toc")}
                 >{chapterObj.text}</span>
               </a>
             </Link>

--- a/pages/components/modules/ChapterTitle.tsx
+++ b/pages/components/modules/ChapterTitle.tsx
@@ -1,31 +1,39 @@
 import Link from "next/link";
 import { Spinner } from "react-bootstrap";
-import { useRouter } from "next/router";
+import { useRouter, NextRouter } from "next/router";
 import { Chapter } from "../../../app/types";
 import styles from "../../../styles/ChapterTitle.module.scss";
 
 interface Props {
   chapter: Chapter;
   toc: number;
-  tocOnClick?: (chapterNumber: number) => number;
+  onLinkClick?: (chapterNumber: number) => number;
   tocTitleRef?: HTMLElement | null;
   effectiveDate?: string;
+  sections?: Section[];
 }
 
 const ChapterTitle = (props: Props): JSX.Element => {
   const {
     chapter,
     toc,
-    tocOnClick,
+    onLinkClick,
     tocTitleRef,
     effectiveDate,
+    sections,
   } = props;
   const key = toc ? "toc" : "chapter";
 
-  const router = useRouter();
+  const router: NextRouter = useRouter();
 
   // Chapter prop or PH zero chapter if unavailable
   const chapterObj = chapter || { chapterNumber: 0, text: "" };
+
+  let sectionObj: Section;
+  if (chapterObj.chapterNumber && !toc) {
+    sectionObj = (sections
+      .find((section) => section.sectionNumber === chapterObj.sectionNumber));
+  }
 
   // If url has no chapter, #100 is added. Display spinner until ready
   const handleZeroChapter = (chapterNumber: number) => (
@@ -41,16 +49,22 @@ const ChapterTitle = (props: Props): JSX.Element => {
           </Spinner>
         </div>)
         : (
-          <div className={styles.chapterText}>
-            {<span
-                key={`${key}${chapterObj.chapterNumber}`}
-              >
-                {chapterObj.chapterNumber}. &nbsp; {chapterObj.text}
-              </span>
+          <div >
+            {
+              <div className={styles.chapterText}>
+                <span
+                  key={`${key}${chapterObj.chapterNumber}`}
+                >
+                  {chapterObj.chapterNumber}. &nbsp; {chapterObj.text}
+                </span>
+                <span className={styles.effectiveDate}>
+                  Effective: &nbsp; {effectiveDate}
+                </span>
+              </div>
             }
             {
-              <span className={styles.effectiveDate}>
-                Effective: &nbsp; {effectiveDate}
+              <span className={styles.sectionSpan}>
+                • &nbsp; {chapterObj.sectionNumber}. &nbsp; {sectionObj.text}
               </span>
             }
           </div>
@@ -76,13 +90,13 @@ const ChapterTitle = (props: Props): JSX.Element => {
               <a>
                 <span
                   className={styles.chapterNum}
-                  onClick={() => tocOnClick(chapterObj.chapterNumber)}
+                  onClick={() => onLinkClick(chapterObj.chapterNumber)}
                 >
                   {chapterObj.chapterNumber}.
                 </span>
                 <span
                   className={styles.chapterTextToc}
-                  onClick={() => tocOnClick(chapterObj.chapterNumber)}
+                  onClick={() => onLinkClick(chapterObj.chapterNumber)}
                 >{chapterObj.text}</span>
               </a>
             </Link>

--- a/pages/components/modules/ChapterTitle.tsx
+++ b/pages/components/modules/ChapterTitle.tsx
@@ -1,4 +1,4 @@
-import { RefObject } from "react";
+import { MutableRefObject, useEffect, useState } from "react";
 import Link from "next/link";
 import { Spinner } from "react-bootstrap";
 import { useRouter, NextRouter } from "next/router";
@@ -7,9 +7,10 @@ import styles from "../../../styles/ChapterTitle.module.scss";
 
 interface Props {
   chapter: Chapter;
+  i?: number;
   toc: number;
   onLinkClick?: (chapterNumber: number, dataSource: string) => void;
-  tocTitleRef?: (node: RefObject<HTMLDivElement>) => void | null;
+  tocTitleRef?: MutableRefObject<HTMLDivElement[]>;
   effectiveDate?: string;
   sections?: Section[];
 }
@@ -17,12 +18,15 @@ interface Props {
 const ChapterTitle = (props: Props): JSX.Element => {
   const {
     chapter,
+    i,
     toc,
     onLinkClick,
     tocTitleRef,
     effectiveDate,
     sections,
   } = props;
+  
+  console.log(i)
   const key = toc ? "toc" : "chapter";
 
   const router: NextRouter = useRouter();
@@ -78,7 +82,7 @@ const ChapterTitle = (props: Props): JSX.Element => {
   return (
     <div>
       { toc ? (
-        <div ref={tocTitleRef}>
+        <div ref={el => tocTitleRef.current[i] = el}>
           <li
             key={`${key}${chapterObj.chapterNumber}`}
             className={styles.chapterList}

--- a/pages/components/modules/ChapterTitle.tsx
+++ b/pages/components/modules/ChapterTitle.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { Spinner } from "react-bootstrap";
 import { useRouter, NextRouter } from "next/router";
-import { Chapter } from "../../../app/types";
+import { Section, Chapter } from "../../../app/types";
 import styles from "../../../styles/ChapterTitle.module.scss";
 
 interface Props {
@@ -27,7 +27,7 @@ const ChapterTitle = (props: Props): JSX.Element => {
   const router: NextRouter = useRouter();
 
   // Chapter prop or PH zero chapter if unavailable
-  const chapterObj = chapter || { chapterNumber: 0, text: "" };
+  const chapterObj = chapter || { chapterNumber: 0, text: "", sectionNumber: 0, type: "chapter" };
 
   let sectionObj: Section;
   if (chapterObj.chapterNumber && !toc) {

--- a/pages/components/modules/CustomErrors.tsx
+++ b/pages/components/modules/CustomErrors.tsx
@@ -1,20 +1,10 @@
 import { useState, useEffect } from "react";
+import { Node } from "simple-text-parser";
 import Custom404 from "../../404";
-import {
-  Section,
-  Chapter,
-  Rule,
-  Subrule,
-  ErrorData
-} from "../../../app/types";
-
-interface Errors {
-  nodes?: (Section | Chapter | Rule | Subrule)[];
-  validChapter?: Chapter | undefined;
-}
+import { ErrorData, ValidateChapter } from "../../../app/types";
 
 interface Props {
-  data: Errors;
+  data: ValidateChapter;
   chapterNumber?: number;
 }
 

--- a/pages/components/modules/CustomErrors.tsx
+++ b/pages/components/modules/CustomErrors.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from "react";
-import { useRouter } from "next/router";
 import Custom404 from "../../404";
-import { Nodes, Chapter } from "../../../app/types";
+import { Nodes, Chapter, ErrorData } from "../../../app/types";
 
 interface Errors {
   nodes?: Nodes;
@@ -15,18 +14,15 @@ interface Props {
 
 const CustomErrors = ((props: Props): JSX.Element | void => {
   const { data, chapterNumber } = props;
-  const [values, setValues] = useState({ reason: "", value: null });
+  const [values, setValues] = useState<ErrorData>({ reason: "", value: null });
 
   useEffect(() => {
-    console.log("customErrors")
     if (data.nodes && !data.nodes.length) {
-      console.log("custom error nodes")
       setValues((prevValue) => ({
         ...prevValue,
         reason: "ruleset-fetch-failed",
       }));
     } else if (!data.validChapter) {
-      console.log("invalid-hash")
       setValues({ reason: "invalid-hash", value: chapterNumber });
     }
   }, [chapterNumber, data]);

--- a/pages/components/modules/CustomErrors.tsx
+++ b/pages/components/modules/CustomErrors.tsx
@@ -1,9 +1,15 @@
 import { useState, useEffect } from "react";
 import Custom404 from "../../404";
-import { Nodes, Chapter, ErrorData } from "../../../app/types";
+import {
+  Section,
+  Chapter,
+  Rule,
+  Subrule,
+  ErrorData
+} from "../../../app/types";
 
 interface Errors {
-  nodes?: Nodes;
+  nodes?: (Section | Chapter | Rule | Subrule)[];
   validChapter?: Chapter | undefined;
 }
 
@@ -12,7 +18,7 @@ interface Props {
   chapterNumber?: number;
 }
 
-const CustomErrors = ((props: Props): JSX.Element | void => {
+const CustomErrors = ((props: Props): JSX.Element => {
   const { data, chapterNumber } = props;
   const [values, setValues] = useState<ErrorData>({ reason: "", value: null });
 

--- a/pages/components/modules/Example.tsx
+++ b/pages/components/modules/Example.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from "next/router";
+import { useRouter, NextRouter } from "next/router";
 import parseLink from "../../../app/parse-link";
 import { Rule, Subrule, RouterValues } from "../../../app/types";
 import styles from "../../../styles/Example.module.scss";
@@ -6,13 +6,14 @@ import styles from "../../../styles/Example.module.scss";
 interface Props {
   rule?: Rule;
   subrule?: Subrule;
+  onLinkClick: (chapterNumber: number) => number;
 }
 
 const Example = (props: Props): JSX.Element => {
-  const { rule, subrule } = props;
+  const { rule, subrule, onLinkClick } = props;
   const data: Rule | Subrule = rule || subrule;
 
-  const router = useRouter();
+  const router: NextRouter = useRouter();
   const routerValues: RouterValues = {
     year: router.query.year,
     version: router.query.version,
@@ -26,7 +27,7 @@ const Example = (props: Props): JSX.Element => {
             key={rule ? `rule-e${index}` : `subrule-e${index}`}
             className={`${styles.example} list-group-item`}
           >
-            {parseLink(data, routerValues, example)}
+            {parseLink(data, routerValues, onLinkClick, example)}
           </li>
         ),
       )}

--- a/pages/components/modules/Example.tsx
+++ b/pages/components/modules/Example.tsx
@@ -14,10 +14,13 @@ const Example = (props: Props): JSX.Element => {
   const data: Rule | Subrule = rule || subrule;
 
   const router: NextRouter = useRouter();
-  const routerValues: RouterValues = {
-    year: router.query.year,
-    version: router.query.version,
-  };
+  const year: string = (Array.isArray(router.query.year))
+    ? router.query.year[0]
+    : router.query.year;
+  const version: string = (Array.isArray(router.query.version))
+    ? router.query.version[0]
+    : router.query.version;
+  const routerValues: RouterValues = { year, version };
 
   return (
     <div>

--- a/pages/components/modules/Example.tsx
+++ b/pages/components/modules/Example.tsx
@@ -6,7 +6,7 @@ import styles from "../../../styles/Example.module.scss";
 interface Props {
   rule?: Rule;
   subrule?: Subrule;
-  onLinkClick: (chapterNumber: number) => number;
+  onLinkClick: (chapterNumber: number, dataSource: string) => void;
 }
 
 const Example = (props: Props): JSX.Element => {
@@ -30,7 +30,11 @@ const Example = (props: Props): JSX.Element => {
             key={rule ? `rule-e${index}` : `subrule-e${index}`}
             className={`${styles.example} list-group-item`}
           >
-            {parseLink(data, routerValues, onLinkClick, example)}
+            {parseLink(
+              (rule)
+              ? {routerValues, onLinkClick, example, rule }
+              : {routerValues, onLinkClick, example, subrule }
+            )}
           </li>
         ),
       )}

--- a/pages/components/modules/RuleGroup.tsx
+++ b/pages/components/modules/RuleGroup.tsx
@@ -1,4 +1,4 @@
-import { RefObject } from "react";
+import { MutableRefObject, RefObject } from "react";
 import { Chapter, Rule, Subrule } from "../../../app/types";
 import RuleList from "./RuleList";
 
@@ -6,7 +6,7 @@ interface Props {
   chapter: Chapter;
   rules: Rule[];
   subrules: Subrule[];
-  elRef: (node: RefObject<HTMLDivElement>) => void | null;
+  elRef: MutableRefObject<HTMLDivElement[]>;
   onLinkClick: (chapterNumber: number, dataSource: string) => void;
 }
 
@@ -29,6 +29,7 @@ const RuleGroup = (props: Props): JSX.Element => {
         <ul key={`c-u${chapter.chapterNumber}`} className={"list-group"}>
           <RuleList
             ruleSubset={ruleSubset}
+            rules={rules}
             subrules={subrules}
             elRef={elRef}
             onLinkClick={onLinkClick}

--- a/pages/components/modules/RuleGroup.tsx
+++ b/pages/components/modules/RuleGroup.tsx
@@ -6,6 +6,7 @@ interface Props {
   rules: Rule[];
   subrules: Subrule[];
   elRef: HTMLDivElement | null;
+  onLinkClick: (chapterNumber: number) => number;
 }
 
 const RuleGroup = (props: Props): JSX.Element => {
@@ -14,6 +15,7 @@ const RuleGroup = (props: Props): JSX.Element => {
     rules,
     subrules,
     elRef,
+    onLinkClick,
   } = props;
 
   const ruleSubset = rules.filter(
@@ -29,6 +31,7 @@ const RuleGroup = (props: Props): JSX.Element => {
             ruleSubset={ruleSubset}
             subrules={subrules}
             elRef={elRef}
+            onLinkClick={onLinkClick}
           />
         </ul>
       )}

--- a/pages/components/modules/RuleGroup.tsx
+++ b/pages/components/modules/RuleGroup.tsx
@@ -1,3 +1,4 @@
+import { RefObject } from "react";
 import { Chapter, Rule, Subrule } from "../../../app/types";
 import RuleList from "./RuleList";
 
@@ -5,7 +6,7 @@ interface Props {
   chapter: Chapter;
   rules: Rule[];
   subrules: Subrule[];
-  elRef: HTMLDivElement | null;
+  elRef: (node: RefObject<HTMLDivElement>) => void | null;
   onLinkClick: (chapterNumber: number, dataSource: string) => void;
 }
 

--- a/pages/components/modules/RuleGroup.tsx
+++ b/pages/components/modules/RuleGroup.tsx
@@ -6,7 +6,7 @@ interface Props {
   rules: Rule[];
   subrules: Subrule[];
   elRef: HTMLDivElement | null;
-  onLinkClick: (chapterNumber: number) => number;
+  onLinkClick: (chapterNumber: number, dataSource: string) => void;
 }
 
 const RuleGroup = (props: Props): JSX.Element => {
@@ -27,7 +27,6 @@ const RuleGroup = (props: Props): JSX.Element => {
       {ruleSubset && (
         <ul key={`c-u${chapter.chapterNumber}`} className={"list-group"}>
           <RuleList
-            chapter={chapter}
             ruleSubset={ruleSubset}
             subrules={subrules}
             elRef={elRef}

--- a/pages/components/modules/RuleList.tsx
+++ b/pages/components/modules/RuleList.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from "next/router";
+import { useRouter, NextRouter } from "next/router";
 import SubruleGroup from "./SubruleGroup";
 import Example from "./Example";
 import parseLink from "../../../app/parse-link";
@@ -9,12 +9,18 @@ interface Props {
   ruleSubset: Rule[];
   subrules: Subrule[];
   elRef: HTMLDivElement | null;
+  onLinkClick: (chapterNumber: number) => number;
 }
 
 const RuleList = (props: Props): JSX.Element => {
-  const { ruleSubset, subrules, elRef } = props;
+  const {
+    ruleSubset,
+    subrules,
+    elRef,
+    onLinkClick,
+  } = props;
 
-  const router = useRouter();
+  const router: NextRouter = useRouter();
   const routerValues: RouterValues = {
     year: router.query.year,
     version: router.query.version,
@@ -29,11 +35,15 @@ const RuleList = (props: Props): JSX.Element => {
               key={`r${rule.ruleNumber}`}
               className={`${styles.ruleText} list-group-item`}
             >
-              {rule.chapterNumber}.{rule.ruleNumber} &nbsp; {parseLink(rule, routerValues)}
+              {rule.chapterNumber}.{rule.ruleNumber} &nbsp; {parseLink(
+                rule,
+                routerValues,
+                onLinkClick,
+              )}
             </li>
           </section>
-          <Example rule={rule} />
-          <SubruleGroup rule={rule} subrules={subrules} />
+          <Example rule={rule} onLinkClick={onLinkClick} />
+          <SubruleGroup rule={rule} subrules={subrules} onLinkClick={onLinkClick} />
         </div>
       ))}
     </div>

--- a/pages/components/modules/RuleList.tsx
+++ b/pages/components/modules/RuleList.tsx
@@ -1,3 +1,4 @@
+import { RefObject } from "react";
 import { useRouter, NextRouter } from "next/router";
 import SubruleGroup from "./SubruleGroup";
 import Example from "./Example";
@@ -8,8 +9,8 @@ import styles from "../../../styles/RuleList.module.scss";
 interface Props {
   ruleSubset: Rule[];
   subrules: Subrule[];
-  elRef: HTMLDivElement | null;
-  onLinkClick: (chapterNumber: number) => number;
+  elRef: (node: RefObject<HTMLDivElement>) => void | null;
+  onLinkClick: (chapterNumber: number, dataSource: string) => void;
 }
 
 const RuleList = (props: Props): JSX.Element => {
@@ -21,10 +22,13 @@ const RuleList = (props: Props): JSX.Element => {
   } = props;
 
   const router: NextRouter = useRouter();
-  const routerValues: RouterValues = {
-    year: router.query.year,
-    version: router.query.version,
-  };
+  const year: string = (Array.isArray(router.query.year))
+    ? router.query.year[0]
+    : router.query.year;
+  const version: string = (Array.isArray(router.query.version))
+    ? router.query.version[0]
+    : router.query.version;
+  const routerValues: RouterValues = { year, version };
 
   return (
     <div>

--- a/pages/components/modules/RuleList.tsx
+++ b/pages/components/modules/RuleList.tsx
@@ -1,4 +1,4 @@
-import { RefObject } from "react";
+import { MutableRefObject, useState } from "react";
 import { useRouter, NextRouter } from "next/router";
 import SubruleGroup from "./SubruleGroup";
 import Example from "./Example";
@@ -8,14 +8,16 @@ import styles from "../../../styles/RuleList.module.scss";
 
 interface Props {
   ruleSubset: Rule[];
+  rules: Rule[];
   subrules: Subrule[];
-  elRef: (node: RefObject<HTMLDivElement>) => void | null;
+  elRef: MutableRefObject<HTMLDivElement[]>;
   onLinkClick: (chapterNumber: number, dataSource: string) => void;
 }
 
 const RuleList = (props: Props): JSX.Element => {
   const {
     ruleSubset,
+    rules,
     subrules,
     elRef,
     onLinkClick,
@@ -33,7 +35,9 @@ const RuleList = (props: Props): JSX.Element => {
   return (
     <div>
       {ruleSubset.map((rule, index) => (
-        <div key={`ruleListDiv-${index}`} className={styles.ruleDiv} ref={elRef}>
+        <div key={`ruleListDiv-${index}`} className={styles.ruleDiv} ref={el => elRef.current[
+          rules.findIndex((r) => r.ruleNumber === rule.ruleNumber && r.chapterNumber === rule.chapterNumber)
+        ] = el}>
           <section id={`${rule.chapterNumber}.${rule.ruleNumber}`}>
             <li
               key={`r${rule.ruleNumber}`}

--- a/pages/components/modules/RuleList.tsx
+++ b/pages/components/modules/RuleList.tsx
@@ -39,11 +39,7 @@ const RuleList = (props: Props): JSX.Element => {
               key={`r${rule.ruleNumber}`}
               className={`${styles.ruleText} list-group-item`}
             >
-              {rule.chapterNumber}.{rule.ruleNumber} &nbsp; {parseLink(
-                rule,
-                routerValues,
-                onLinkClick,
-              )}
+              {rule.chapterNumber}.{rule.ruleNumber} &nbsp; {parseLink({routerValues, onLinkClick, rule})}
             </li>
           </section>
           <Example rule={rule} onLinkClick={onLinkClick} />

--- a/pages/components/modules/RulesetForm.tsx
+++ b/pages/components/modules/RulesetForm.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 import { useRouter, NextRouter } from "next/router";
 import formValidation from "../../../app/form-validation";
+import { RouterValues } from "../../../app/types";
 import styles from "../../../styles/RulesetForm.module.scss";
 
 interface Props {
@@ -21,10 +22,13 @@ const RulesetForm = (props: Props): JSX.Element => {
 
   // Get url query values
   const router: NextRouter = useRouter();
-  const routerValues: RouterValues = {
-    year: router.query.year,
-    version: router.query.version,
-  };
+  const year: string = (Array.isArray(router.query.year))
+    ? router.query.year[0]
+    : router.query.year;
+  const version: string = (Array.isArray(router.query.version))
+    ? router.query.version[0]
+    : router.query.version;
+  const routerValues: RouterValues = { year, version };
   const initUrl = `https://media.wizards.com/${routerValues.year}/downloads/MagicCompRules%${routerValues.version}.txt`;
 
   // Set initial url on page load

--- a/pages/components/modules/RulesetForm.tsx
+++ b/pages/components/modules/RulesetForm.tsx
@@ -47,9 +47,9 @@ const RulesetForm = (props: Props): JSX.Element => {
 
     // Get version and year from rulsetUrl link
     const reVersion = /\d{10}/;
-    const version: number = reVersion.test(rulesetUrl) ? rulesetUrl.match(reVersion)[0] : 0;
+    const version: string = reVersion.test(rulesetUrl) ? rulesetUrl.match(reVersion)[0] : "";
     const reYear = /\d{4}/;
-    const year: number = reYear.test(rulesetUrl) ? rulesetUrl.match(reYear)[0] : 0;
+    const year: string = reYear.test(rulesetUrl) ? rulesetUrl.match(reYear)[0] : "";
 
     // That ruleset is already displayed
     if (routerValues.version === version && routerValues.year === year) {

--- a/pages/components/modules/RulesetForm.tsx
+++ b/pages/components/modules/RulesetForm.tsx
@@ -5,7 +5,7 @@ import {
   FormEvent,
   ChangeEvent,
 } from "react";
-import { useRouter } from "next/router";
+import { useRouter, NextRouter } from "next/router";
 import formValidation from "../../../app/form-validation";
 import styles from "../../../styles/RulesetForm.module.scss";
 
@@ -20,7 +20,7 @@ const RulesetForm = (props: Props): JSX.Element => {
   const [url, setUrl] = useState("");
 
   // Get url query values
-  const router = useRouter();
+  const router: NextRouter = useRouter();
   const routerValues: RouterValues = {
     year: router.query.year,
     version: router.query.version,

--- a/pages/components/modules/SectionList.tsx
+++ b/pages/components/modules/SectionList.tsx
@@ -1,4 +1,4 @@
-import { RefObject } from "react";
+import { RefObject, LegacyRef } from "react";
 import { Spinner } from "react-bootstrap";
 import ChapterList from "./ChapterList";
 import {
@@ -14,7 +14,7 @@ interface Props {
   chapters: Chapter[];
   rules: Rule[];
   subrules: Subrule[];
-  elRef: (node: RefObject<HTMLDivElement>) => void | null;
+  elRef: (node: LegacyRef<HTMLDivElement>) => void | null;
   root: RefObject<HTMLDivElement> | null;
   onLinkClick: (chapterNumber: number, dataSource: string) => void;
 }

--- a/pages/components/modules/SectionList.tsx
+++ b/pages/components/modules/SectionList.tsx
@@ -15,6 +15,7 @@ interface Props {
   subrules: Subrule[];
   elRef: HTMLDivElement | null;
   root: HTMLDivElement | null;
+  onLinkClick: (chapterNumber: number) => number;
 }
 
 const SectionList = (props: Props): JSX.Element => {
@@ -25,6 +26,7 @@ const SectionList = (props: Props): JSX.Element => {
     subrules,
     elRef,
     root,
+    onLinkClick,
   } = props;
 
   return (
@@ -40,6 +42,7 @@ const SectionList = (props: Props): JSX.Element => {
               rules={rules}
               subrules={subrules}
               elRef={elRef}
+              onLinkClick={onLinkClick}
             />
           </div>
         )))

--- a/pages/components/modules/SectionList.tsx
+++ b/pages/components/modules/SectionList.tsx
@@ -1,3 +1,4 @@
+import { RefObject } from "react";
 import { Spinner } from "react-bootstrap";
 import ChapterList from "./ChapterList";
 import {
@@ -13,8 +14,8 @@ interface Props {
   chapters: Chapter[];
   rules: Rule[];
   subrules: Subrule[];
-  elRef: HTMLDivElement | null;
-  root: HTMLDivElement | null;
+  elRef: (node: RefObject<HTMLDivElement>) => void | null;
+  root: RefObject<HTMLDivElement> | null;
   onLinkClick: (chapterNumber: number, dataSource: string) => void;
 }
 

--- a/pages/components/modules/SectionList.tsx
+++ b/pages/components/modules/SectionList.tsx
@@ -15,7 +15,7 @@ interface Props {
   subrules: Subrule[];
   elRef: HTMLDivElement | null;
   root: HTMLDivElement | null;
-  onLinkClick: (chapterNumber: number) => number;
+  onLinkClick: (chapterNumber: number, dataSource: string) => void;
 }
 
 const SectionList = (props: Props): JSX.Element => {

--- a/pages/components/modules/SectionList.tsx
+++ b/pages/components/modules/SectionList.tsx
@@ -34,8 +34,6 @@ const SectionList = (props: Props): JSX.Element => {
       {sections.length
         ? (sections.map((section, index) => (
           <div key={`${section.sectionNumber}-${index}`}>
-            <section id={`${section.sectionNumber}`}>
-            </section>
             <ChapterList
               section={section}
               chapters={chapters}

--- a/pages/components/modules/SubruleGroup.tsx
+++ b/pages/components/modules/SubruleGroup.tsx
@@ -4,10 +4,11 @@ import SubruleList from "./SubruleList";
 interface Props {
   rule: Rule;
   subrules: Subrule[];
+  onLinkClick: (chapterNumber: number) => number;
 }
 
 const SubruleGroup = (props: Props): JSX.Element => {
-  const { rule, subrules } = props;
+  const { rule, subrules, onLinkClick } = props;
 
   const subruleSubset = subrules.filter(
     (subrule) => rule.ruleNumber === subrule.ruleNumber
@@ -18,7 +19,7 @@ const SubruleGroup = (props: Props): JSX.Element => {
     <div>
       {subruleSubset && (
         <ul className={"list-group"}>
-          <SubruleList subruleSubset={subruleSubset} />
+          <SubruleList subruleSubset={subruleSubset} onLinkClick={onLinkClick} />
         </ul>
       )}
     </div>

--- a/pages/components/modules/SubruleGroup.tsx
+++ b/pages/components/modules/SubruleGroup.tsx
@@ -4,7 +4,7 @@ import SubruleList from "./SubruleList";
 interface Props {
   rule: Rule;
   subrules: Subrule[];
-  onLinkClick: (chapterNumber: number) => number;
+  onLinkClick: (chapterNumber: number, dataSource: string) => void;
 }
 
 const SubruleGroup = (props: Props): JSX.Element => {

--- a/pages/components/modules/SubruleList.tsx
+++ b/pages/components/modules/SubruleList.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from "next/router";
+import { useRouter, NextRouter } from "next/router";
 import Example from "./Example";
 import parseLink from "../../../app/parse-link";
 import { Subrule, RouterValues } from "../../../app/types";
@@ -6,12 +6,13 @@ import styles from "../../../styles/SubruleList.module.scss";
 
 interface Props {
   subruleSubset: Subrule[];
+  onLinkClick: (chapterNumber: number) => number;
 }
 
 const SubruleList = (props: Props): JSX.Element => {
-  const { subruleSubset } = props;
+  const { subruleSubset, onLinkClick } = props;
 
-  const router = useRouter();
+  const router: NextRouter = useRouter();
   const routerValues: RouterValues = {
     year: router.query.year,
     version: router.query.version,
@@ -29,10 +30,14 @@ const SubruleList = (props: Props): JSX.Element => {
               className={`${styles.subruleText} list-group-item`}
             >
               {subrule.chapterNumber}.{subrule.ruleNumber}
-              {subrule.subruleLetter} &nbsp; {parseLink(subrule, routerValues)}
+              {subrule.subruleLetter} &nbsp; {parseLink(
+                subrule,
+                routerValues,
+                onLinkClick,
+              )}
             </li>
           </section>
-          <Example subrule={subrule} />
+          <Example subrule={subrule} onLinkClick={onLinkClick}/>
         </div>
       ))}
     </div>

--- a/pages/components/modules/SubruleList.tsx
+++ b/pages/components/modules/SubruleList.tsx
@@ -6,17 +6,20 @@ import styles from "../../../styles/SubruleList.module.scss";
 
 interface Props {
   subruleSubset: Subrule[];
-  onLinkClick: (chapterNumber: number) => number;
+  onLinkClick: (chapterNumber: number, dataSource: string) => void;
 }
 
 const SubruleList = (props: Props): JSX.Element => {
   const { subruleSubset, onLinkClick } = props;
 
   const router: NextRouter = useRouter();
-  const routerValues: RouterValues = {
-    year: router.query.year,
-    version: router.query.version,
-  };
+  const year: string = (Array.isArray(router.query.year))
+    ? router.query.year[0]
+    : router.query.year;
+  const version: string = (Array.isArray(router.query.version))
+    ? router.query.version[0]
+    : router.query.version;
+  const routerValues: RouterValues = { year, version };
 
   return (
     <div>
@@ -30,11 +33,7 @@ const SubruleList = (props: Props): JSX.Element => {
               className={`${styles.subruleText} list-group-item`}
             >
               {subrule.chapterNumber}.{subrule.ruleNumber}
-              {subrule.subruleLetter} &nbsp; {parseLink(
-                subrule,
-                routerValues,
-                onLinkClick,
-              )}
+              {subrule.subruleLetter} &nbsp; {parseLink({ routerValues, onLinkClick, subrule })}
             </li>
           </section>
           <Example subrule={subrule} onLinkClick={onLinkClick}/>

--- a/pages/components/modules/TocChapterList.tsx
+++ b/pages/components/modules/TocChapterList.tsx
@@ -6,7 +6,7 @@ interface Props {
   chapters: Chapter[];
   sectionNumber: number;
   toc: number;
-  tocOnClick: (chapterNumber: number) => number;
+  onLinkClick: (chapterNumber: number) => number;
   tocTitleRef: HTMLElement | null;
 }
 
@@ -15,7 +15,7 @@ const TocChapterList = (props: Props): JSX.Element => {
     chapters,
     sectionNumber,
     toc,
-    tocOnClick,
+    onLinkClick,
     tocTitleRef,
   } = props;
 
@@ -28,7 +28,7 @@ const TocChapterList = (props: Props): JSX.Element => {
           <ChapterTitle
             chapter={chapter}
             toc={toc}
-            tocOnClick={tocOnClick}
+            onLinkClick={onLinkClick}
             tocTitleRef={tocTitleRef}
           />
         </ul>

--- a/pages/components/modules/TocChapterList.tsx
+++ b/pages/components/modules/TocChapterList.tsx
@@ -1,3 +1,4 @@
+import { RefObject } from "react";
 import ChapterTitle from "./ChapterTitle";
 import { Chapter } from "../../../app/types";
 import styles from "../../../styles/TocChapterList.module.scss";
@@ -7,7 +8,7 @@ interface Props {
   sectionNumber: number;
   toc: number;
   onLinkClick: (chapterNumber: number, dataSource: string) => void;
-  tocTitleRef: HTMLDivElement | null;
+  tocTitleRef: (node: RefObject<HTMLDivElement>) => void | null;
 }
 
 const TocChapterList = (props: Props): JSX.Element => {

--- a/pages/components/modules/TocChapterList.tsx
+++ b/pages/components/modules/TocChapterList.tsx
@@ -1,4 +1,4 @@
-import { RefObject } from "react";
+import { MutableRefObject } from "react";
 import ChapterTitle from "./ChapterTitle";
 import { Chapter } from "../../../app/types";
 import styles from "../../../styles/TocChapterList.module.scss";
@@ -8,7 +8,7 @@ interface Props {
   sectionNumber: number;
   toc: number;
   onLinkClick: (chapterNumber: number, dataSource: string) => void;
-  tocTitleRef: (node: RefObject<HTMLDivElement>) => void | null;
+  tocTitleRef: MutableRefObject<HTMLDivElement[]>;
 }
 
 const TocChapterList = (props: Props): JSX.Element => {
@@ -31,6 +31,7 @@ const TocChapterList = (props: Props): JSX.Element => {
             toc={toc}
             onLinkClick={onLinkClick}
             tocTitleRef={tocTitleRef}
+            i={chapters.findIndex((ch) => ch.chapterNumber === chapter.chapterNumber)}
           />
         </ul>
       ))}

--- a/pages/components/modules/TocChapterList.tsx
+++ b/pages/components/modules/TocChapterList.tsx
@@ -6,8 +6,8 @@ interface Props {
   chapters: Chapter[];
   sectionNumber: number;
   toc: number;
-  onLinkClick: (chapterNumber: number) => number;
-  tocTitleRef: HTMLElement | null;
+  onLinkClick: (chapterNumber: number, dataSource: string) => void;
+  tocTitleRef: HTMLDivElement | null;
 }
 
 const TocChapterList = (props: Props): JSX.Element => {

--- a/pages/components/modules/TocSections.tsx
+++ b/pages/components/modules/TocSections.tsx
@@ -5,7 +5,7 @@ import styles from "../../../styles/TocSections.module.scss";
 interface Props {
   sections: Section[];
   chapters: Chapter[];
-  tocOnClick: (chapterNumber: number) => number;
+  onLinkClick: (chapterNumber: number) => number;
   tocTitleRef: HTMLElement | null;
 }
 
@@ -13,7 +13,7 @@ const TocSections = (props: Props): JSX.Element => {
   const {
     sections,
     chapters,
-    tocOnClick,
+    onLinkClick,
     tocTitleRef,
   } = props;
 
@@ -28,7 +28,7 @@ const TocSections = (props: Props): JSX.Element => {
             sectionNumber={section.sectionNumber}
             chapters={chapters}
             toc="1"
-            tocOnClick={tocOnClick}
+            onLinkClick={onLinkClick}
             tocTitleRef={tocTitleRef}
           />
         </div>

--- a/pages/components/modules/TocSections.tsx
+++ b/pages/components/modules/TocSections.tsx
@@ -5,8 +5,8 @@ import styles from "../../../styles/TocSections.module.scss";
 interface Props {
   sections: Section[];
   chapters: Chapter[];
-  onLinkClick: (chapterNumber: number) => number;
-  tocTitleRef: HTMLElement | null;
+  onLinkClick: (chapterNumber: number, dataSource: string) => void;
+  tocTitleRef: HTMLDivElement | null;
 }
 
 const TocSections = (props: Props): JSX.Element => {
@@ -27,7 +27,7 @@ const TocSections = (props: Props): JSX.Element => {
           <TocChapterList
             sectionNumber={section.sectionNumber}
             chapters={chapters}
-            toc="1"
+            toc={1}
             onLinkClick={onLinkClick}
             tocTitleRef={tocTitleRef}
           />

--- a/pages/components/modules/TocSections.tsx
+++ b/pages/components/modules/TocSections.tsx
@@ -1,3 +1,4 @@
+import { RefObject } from "react";
 import TocChapterList from "./TocChapterList";
 import { Section, Chapter } from "../../../app/types";
 import styles from "../../../styles/TocSections.module.scss";
@@ -6,7 +7,7 @@ interface Props {
   sections: Section[];
   chapters: Chapter[];
   onLinkClick: (chapterNumber: number, dataSource: string) => void;
-  tocTitleRef: HTMLDivElement | null;
+  tocTitleRef: (node: RefObject<HTMLDivElement>) => void | null;
 }
 
 const TocSections = (props: Props): JSX.Element => {

--- a/pages/components/modules/useTopRule.ts
+++ b/pages/components/modules/useTopRule.ts
@@ -7,7 +7,7 @@ import {
 } from "react";
 
 const useTopRule = (
-  refArray: RefObject<HTMLDivElement>[] = null,
+  refArray: HTMLDivElement[] = null,
   root: RefObject<HTMLDivElement> | null = null,
 ): number | void => {
   const observerRef = useRef<IntersectionObserver>(null);
@@ -16,7 +16,7 @@ const useTopRule = (
   const callback = useCallback(([entry]) => {
     if (entry.isIntersecting) {
       console.log(entry);
-      setRuleNumber(Number(entry.target.outerText.match(/(\d{3})/g)[0]));
+      setRuleNumber(Number(entry.target.innerText.match(/(\d{3})/g)[0]));
     }
   }, []);
 

--- a/pages/components/modules/useTopRule.ts
+++ b/pages/components/modules/useTopRule.ts
@@ -1,17 +1,17 @@
 import {
   useEffect,
   useRef,
-  RefObject,
   useCallback,
   useState,
+  RefObject,
 } from "react";
 
 const useTopRule = (
-  refArray: RefObject<HTMLElement>[] = null,
+  refArray: RefObject<HTMLDivElement>[] = null,
   root: RefObject<HTMLDivElement> | null = null,
 ): number | void => {
   const observerRef = useRef<IntersectionObserver>(null);
-  const [ruleNumber, setRuleNumber] = useState();
+  const [ruleNumber, setRuleNumber] = useState<number>();
 
   const callback = useCallback(([entry]) => {
     if (entry.isIntersecting) {
@@ -24,7 +24,7 @@ const useTopRule = (
     // IntersectionRect set to top of .scrollableDiv viewport
     const options = {
       rootMargin: "0px 0px -99% 0px",
-      root,
+      root: root.current,
     };
 
     observerRef.current = new IntersectionObserver(callback, options);
@@ -40,6 +40,8 @@ const useTopRule = (
     refArray.forEach((r) => {
       observerRef.current.observe(r);
     });
+    
+    
   }, [refArray]);
 
   // Cleanup

--- a/pages/rules/[year]/[version].tsx
+++ b/pages/rules/[year]/[version].tsx
@@ -207,31 +207,38 @@ const RuleSetPage = (props: Props): JSX.Element => {
     callbackNumber = callbackChapterNumber;
   }
 
+  // Scroll ToC to chapterTitle corresponding to url hash value
+  const scrollToc = (chapterNumber: number) => {
+    const re = new RegExp(`(${chapterNumber})`);
+    const element = refTocArray.find((elem) => re.test(elem.outerText));
+    element.scrollIntoView();
+  };
+
   // Prop used by ToC links and section list viewport links
-  const onLinkClick = (chapterN: number): number => {
-    // chapterN can be a 3 digit chapter number or a single digit section number
-    const linkNumber: number = (/\d{1}/.test(chapterN))
-      ? chapterN * 100
-      : chapterN;
+  const onLinkClick = (chapterN: number, dataSource: string): number => {
+    // If chapterN comes from a sectionList viewport link, scroll Toc
+    if (dataSource === "rules") {
+      scrollToc(chapterN);
+    }
 
     let source: string;
     // Initiate a pause as chapterNumber is supplied by prop
     setPause(true);
     const { chapterNumber } = chapterValues;
-    if (chapterNumber && linkNumber < chapterNumber) {
+    if (chapterNumber && chapterN < chapterNumber) {
       source = "prop decrease";
-    } else if (chapterNumber && linkNumber > chapterNumber) {
+    } else if (chapterNumber && chapterN > chapterNumber) {
       source = "prop increase";
     }
 
     // Save value from prop
-    if (chapterValues.chapterNumber !== linkNumber) {
+    if (chapterValues.chapterNumber !== chapterN) {
       setChapterValues((prevValue) => ({
         ...prevValue,
-        chapterNumber: linkNumber,
-        anchorValue: linkNumber,
+        chapterNumber: chapterN,
+        anchorValue: chapterN,
         source,
-        propValue: linkNumber,
+        propValue: chapterN,
       }));
     }
   };
@@ -257,9 +264,7 @@ const RuleSetPage = (props: Props): JSX.Element => {
       }));
 
       // Scroll ToC viewport to anchor tag's chapter title
-      const re = new RegExp(`(${chapterValues.chapterNumber})`);
-      const element = refTocArray.find((elem) => re.test(elem.outerText));
-      element.scrollIntoView();
+      scrollToc(chapterValues.chapterNumber);
     } else if (callbackNumber
       && !pause
       && chapterValues.chapterNumber !== callbackNumber

--- a/pages/rules/[year]/[version].tsx
+++ b/pages/rules/[year]/[version].tsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
   RefObject,
 } from "react";
+import { Node } from "simple-text-parser";
 import sortBy from "lodash/sortBy";
 import { useRouter, NextRouter } from "next/router";
 import { Spinner, Tabs, Tab } from "react-bootstrap";
@@ -23,24 +24,10 @@ import {
   Chapter,
   Rule,
   Subrule,
+  GetStaticPropsResult,
+  ValidateChapter,
 } from "../../../app/types";
 import styles from "../../../styles/[version].module.scss";
-
-interface Props {
-  nodes: void | (Section | Chapter | Rule | Subrule)[];
-  effectiveDate: string;
-}
-
-interface GetStaticPropsResult {
-  props: Props | {};
-  revalidate?: number;
-  notFound?: boolean;
-}
-
-interface ValidateChapter {
-  nodes: (Section | Chapter | Rule | Subrule)[];
-  validChapter: Chapter | undefined | boolean;
-}
 
 export const getStaticProps = async ({ params }): Promise<GetStaticPropsResult> => {
   // Fetch rule set
@@ -48,7 +35,7 @@ export const getStaticProps = async ({ params }): Promise<GetStaticPropsResult> 
   const res = await fetch(url);
   const rawRuleSetText: string = await res.text();
   // Parse rules text to an array of rule nodes
-  const nodes: void | Nodes = await rulesParse(rawRuleSetText);
+  const nodes: Node[] = await rulesParse(rawRuleSetText);
 
   // Parse rules text for effective date
   const effectiveDateRegex = /(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{2}),\s+(\d{4})/gm;

--- a/styles/ChapterTitle.module.scss
+++ b/styles/ChapterTitle.module.scss
@@ -38,3 +38,9 @@
 .effectiveDate {
   margin-right: 36px;
 }
+
+.sectionSpan {
+  margin-left: 8px;
+  font-size: 14px;
+  color: grey;
+}

--- a/styles/[version].module.scss
+++ b/styles/[version].module.scss
@@ -36,7 +36,6 @@
 .chapterTitleContainer {
   position: fixed;
   width: 100%;
-  height: 10%;
   z-index: 1;
   top: 20%
 }

--- a/styles/[version].module.scss
+++ b/styles/[version].module.scss
@@ -36,17 +36,17 @@
 .chapterTitleContainer {
   position: fixed;
   width: 100%;
+  height: 10%;
   z-index: 1;
   top: 20%
 }
 
 .rulesContainer {
   position: absolute;
-  height: 75vh;
+  height: 68vh;
   overflow: hidden;
-  // overflow-y: scroll;
   z-index: 0;
-  top: 180px;
+  top: 220px;
 }
 
 .spinnerDiv {

--- a/yarn.lock
+++ b/yarn.lock
@@ -184,6 +184,18 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash.sortby@^4.7.6":
+  version "4.7.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.sortby/-/lodash.sortby-4.7.6.tgz#eed689835f274b553db4ae16a4a23f58b79618a1"
+  integrity sha512-EnvAOmKvEg7gdYpYrS6+fVFPw5dL9rBnJi3vcKI7wqWQcLJVF/KRXK9dH29HjGNVvFUj0s9prRP3J8jEGnGKDw==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.171"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.171.tgz#f01b3a5fe3499e34b622c362a46a609fdb23573b"
+  integrity sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg==
+
 "@types/node@*":
   version "15.12.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.5.tgz#9a78318a45d75c9523d2396131bd3cca54b2d185"


### PR DESCRIPTION
- Several refactors to resolve TypeScript errors.
- ParseLinks now filters nodes and returns an object of four node arrays
- Switched to useRefs to obtain an array of RuleList div and toc ChapterTitle div refs