### PR TITLE
Update to creating links in rule viewport

### DIFF
--- a/app/components/ChapterList.tsx
+++ b/app/components/ChapterList.tsx
@@ -49,6 +49,7 @@ const ChapterList = (props: Props): JSX.Element => {
             elRef={elRef}
             onLinkClick={onLinkClick}
             searchResults={searchResults}
+            allChaptersN={chapters.map((chapter) => chapter.chapterNumber)}
           />
         </div>
       ))}

--- a/app/components/ExampleText.tsx
+++ b/app/components/ExampleText.tsx
@@ -9,10 +9,11 @@ interface Props {
   subrule?: Subrule;
   onLinkClick: (chapterNumber: number, dataSource: string) => void;
   searchResults: SearchResults;
+  allChaptersN: string[];
 }
 
 const ExampleText = (props: Props): JSX.Element => {
-  const { rule, subrule, onLinkClick, searchResults } = props;
+  const { rule, subrule, onLinkClick, searchResults, allChaptersN } = props;
   const data: Rule | Subrule = rule || subrule;
   // Use regular array of example strings if no searchTerm
   const exampleText =
@@ -47,6 +48,7 @@ const ExampleText = (props: Props): JSX.Element => {
                           example,
                           rule,
                           searchResults,
+                          allChaptersN,
                         }
                       : {
                           routerValues,
@@ -54,6 +56,7 @@ const ExampleText = (props: Props): JSX.Element => {
                           example,
                           subrule,
                           searchResults,
+                          allChaptersN,
                         }
                   )
                 : modifySearchRules(
@@ -67,6 +70,7 @@ const ExampleText = (props: Props): JSX.Element => {
                             example,
                             rule,
                             searchResults,
+                            allChaptersN,
                           }),
                         }
                       : {
@@ -78,6 +82,7 @@ const ExampleText = (props: Props): JSX.Element => {
                             example,
                             subrule,
                             searchResults,
+                            allChaptersN,
                           }),
                         }
                   )}

--- a/app/components/RuleGroup.tsx
+++ b/app/components/RuleGroup.tsx
@@ -9,10 +9,19 @@ interface Props {
   elRef: MutableRefObject<HTMLDivElement[]>;
   onLinkClick: (chapterNumber: number, dataSource: string) => void;
   searchResults: SearchResults;
+  allChaptersN: string[];
 }
 
 const RuleGroup = (props: Props): JSX.Element => {
-  const { chapter, rules, subrules, elRef, onLinkClick, searchResults } = props;
+  const {
+    chapter,
+    rules,
+    subrules,
+    elRef,
+    onLinkClick,
+    searchResults,
+    allChaptersN,
+  } = props;
 
   const ruleSubset = rules.filter(
     (rule) => rule.chapterNumber === chapter.chapterNumber
@@ -29,6 +38,7 @@ const RuleGroup = (props: Props): JSX.Element => {
             elRef={elRef}
             onLinkClick={onLinkClick}
             searchResults={searchResults}
+            allChaptersN={allChaptersN}
           />
         </ul>
       )}

--- a/app/components/RuleList.tsx
+++ b/app/components/RuleList.tsx
@@ -14,11 +14,19 @@ interface Props {
   elRef: MutableRefObject<HTMLDivElement[]>;
   onLinkClick: (chapterNumber: number, dataSource: string) => void;
   searchResults: SearchResults;
+  allChaptersN: string[];
 }
 
 const RuleList = (props: Props): JSX.Element => {
-  const { ruleSubset, rules, subrules, elRef, onLinkClick, searchResults } =
-    props;
+  const {
+    ruleSubset,
+    rules,
+    subrules,
+    elRef,
+    onLinkClick,
+    searchResults,
+    allChaptersN,
+  } = props;
 
   const router: NextRouter = useRouter();
   const year: string = Array.isArray(router.query.year)
@@ -53,7 +61,13 @@ const RuleList = (props: Props): JSX.Element => {
             >
               {rule.chapterNumber}.{rule.ruleNumber} &nbsp;
               {!searchResults.searchTerm
-                ? parseLink({ routerValues, onLinkClick, rule, searchResults })
+                ? parseLink({
+                    routerValues,
+                    onLinkClick,
+                    rule,
+                    searchResults,
+                    allChaptersN,
+                  })
                 : modifySearchRules({
                     searchTerm: searchResults.searchTerm,
                     rule,
@@ -62,6 +76,7 @@ const RuleList = (props: Props): JSX.Element => {
                       onLinkClick,
                       rule,
                       searchResults,
+                      allChaptersN,
                     }),
                   })}
             </li>
@@ -70,12 +85,14 @@ const RuleList = (props: Props): JSX.Element => {
             rule={rule}
             onLinkClick={onLinkClick}
             searchResults={searchResults}
+            allChaptersN={allChaptersN}
           />
           <SubruleGroup
             rule={rule}
             subrules={subrules}
             onLinkClick={onLinkClick}
             searchResults={searchResults}
+            allChaptersN={allChaptersN}
           />
         </div>
       ))}

--- a/app/components/SubruleGroup.tsx
+++ b/app/components/SubruleGroup.tsx
@@ -6,10 +6,11 @@ interface Props {
   subrules: Subrule[];
   onLinkClick: (chapterNumber: number, dataSource: string) => void;
   searchResults: SearchResults;
+  allChaptersN: string[];
 }
 
 const SubruleGroup = (props: Props): JSX.Element => {
-  const { rule, subrules, onLinkClick, searchResults } = props;
+  const { rule, subrules, onLinkClick, searchResults, allChaptersN } = props;
 
   const subruleSubset = subrules.filter(
     (subrule) =>
@@ -25,6 +26,7 @@ const SubruleGroup = (props: Props): JSX.Element => {
             subruleSubset={subruleSubset}
             onLinkClick={onLinkClick}
             searchResults={searchResults}
+            allChaptersN={allChaptersN}
           />
         </ul>
       )}

--- a/app/components/SubruleList.tsx
+++ b/app/components/SubruleList.tsx
@@ -9,10 +9,11 @@ interface Props {
   subruleSubset: Subrule[];
   onLinkClick: (chapterNumber: number, dataSource: string) => void;
   searchResults: SearchResults;
+  allChaptersN: string[];
 }
 
 const SubruleList = (props: Props): JSX.Element => {
-  const { subruleSubset, onLinkClick, searchResults } = props;
+  const { subruleSubset, onLinkClick, searchResults, allChaptersN } = props;
 
   const router: NextRouter = useRouter();
   const year: string = Array.isArray(router.query.year)
@@ -42,6 +43,7 @@ const SubruleList = (props: Props): JSX.Element => {
                     onLinkClick,
                     subrule,
                     searchResults,
+                    allChaptersN,
                   })
                 : modifySearchRules({
                     searchTerm: searchResults.searchTerm,
@@ -51,6 +53,7 @@ const SubruleList = (props: Props): JSX.Element => {
                       onLinkClick,
                       subrule,
                       searchResults,
+                      allChaptersN,
                     }),
                   })}
             </li>
@@ -59,6 +62,7 @@ const SubruleList = (props: Props): JSX.Element => {
             subrule={subrule}
             onLinkClick={onLinkClick}
             searchResults={searchResults}
+            allChaptersN={allChaptersN}
           />
         </div>
       ))}

--- a/app/typing/types.ts
+++ b/app/typing/types.ts
@@ -60,6 +60,7 @@ export interface ParseLinkArgs {
   rule?: Rule;
   subrule?: Subrule;
   searchResults: SearchResults;
+  allChaptersN: string[];
 }
 
 export interface ReplaceRuleNumbers {

--- a/app/utils/replace-rule-numbers.tsx
+++ b/app/utils/replace-rule-numbers.tsx
@@ -19,12 +19,12 @@ const replaceRuleNumbers = (args: ReplaceRuleNumbers): ReactNodeArray => {
     updatedText = reactStringReplace(
       !index ? text : updatedText,
       ruleNumber,
-      (match: string, i: number) => (
+      (match: string, i: number, offset: number) => (
         <span
           key={
             rule
-              ? `${rule.ruleNumber}-${ruleNumber}-${i}`
-              : `${subrule.ruleNumber}${subrule.subruleLetter}-${ruleNumber}-${i}`
+              ? `${rule.ruleNumber}-${ruleNumber}-${i}${offset}`
+              : `${subrule.ruleNumber}${subrule.subruleLetter}-${ruleNumber}-${i}${offset}`
           }
         >
           <Link

--- a/pages/rules/[year]/[version].tsx
+++ b/pages/rules/[year]/[version].tsx
@@ -427,7 +427,11 @@ const RuleSetPage = (props: DynamicProps): JSX.Element => {
                 </Tabs>
               </div>
               <div className={styles.chapterTitleContainer}>
-                {!searchData.searchTerm && searchResults.searchResult ? (
+                {searchData.searchTerm &&
+                !searchResults.searchResult &&
+                searchData.searchCompleted ? (
+                  <NoSearchResults title={1} />
+                ) : (
                   <ChapterTitle
                     chapter={chapters.find(
                       (chapter) =>
@@ -437,12 +441,14 @@ const RuleSetPage = (props: DynamicProps): JSX.Element => {
                     effectiveDate={effectiveDate}
                     sections={sections}
                   />
-                ) : (
-                  <NoSearchResults title={1} />
                 )}
               </div>
               <div className={styles.rulesContainer}>
-                {!searchData.searchTerm && searchResults.searchResult ? (
+                {searchData.searchTerm &&
+                !searchResults.searchResult &&
+                searchData.searchCompleted ? (
+                  <NoSearchResults title={0} />
+                ) : (
                   <SectionList
                     sections={sections}
                     chapters={chapters}
@@ -461,8 +467,6 @@ const RuleSetPage = (props: DynamicProps): JSX.Element => {
                     onLinkClick={onLinkClick}
                     searchResults={searchResults}
                   />
-                ) : (
-                  <NoSearchResults title={0} />
                 )}
               </div>
             </div>


### PR DESCRIPTION
- Refactored parseLink regexes
- Removed unnecessary filtering with improved regexes
- Pass an array of chapterNumbers to parseLinks, and filter matchArray to eliminate invalid chapter numbers, like 999
- Updated conditions for the no search results component to display. A term was input, there was no result, and the search was marked completed
    - searchData.searchTerm is true
    - searchResults.searchResult is null 
    - searchData.searchCompleted is true