### PR TITLE
Em examples

### DIFF
--- a/app/components/ExampleText.tsx
+++ b/app/components/ExampleText.tsx
@@ -1,6 +1,7 @@
 import { useRef, useEffect } from "react";
 import { useRouter, NextRouter } from "next/router";
 import parseLink from "../utils/parse-link";
+import modifyExampleText from "../utils/modify-example-text";
 import modifySearchRules from "../utils/modify-search-rules";
 import { Rule, Subrule, RouterValues, SearchResults } from "../typing/types";
 import styles from "../styles/ExampleText.module.scss";
@@ -75,37 +76,19 @@ const ExampleText = (props: Props): JSX.Element => {
               {/* eslint-disable-next-line no-return-assign */}
               <div ref={(el) => (innerContainerDiv.current[index] = el)}>
                 <span>
-                  {rule
-                    ? `${rule.chapterNumber}.${rule.ruleNumber} `
-                    : `${subrule.chapterNumber}.${subrule.ruleNumber}${subrule.subruleLetter} `}
+                  <em>
+                    {rule
+                      ? `${rule.chapterNumber}.${rule.ruleNumber} `
+                      : `${subrule.chapterNumber}.${subrule.ruleNumber}${subrule.subruleLetter} `}
+                  </em>
                 </span>
                 <span>
                   {!searchResults.searchTerm
-                    ? parseLink(
+                    ? modifyExampleText(
                         rule
                           ? {
-                              routerValues,
-                              onLinkClick,
-                              example,
                               rule,
-                              searchResults,
-                              allChaptersN,
-                            }
-                          : {
-                              routerValues,
-                              onLinkClick,
-                              example,
-                              subrule,
-                              searchResults,
-                              allChaptersN,
-                            }
-                      )
-                    : modifySearchRules(
-                        rule
-                          ? {
-                              searchResults,
-                              rule,
-                              toModify: parseLink({
+                              exampleText: parseLink({
                                 routerValues,
                                 onLinkClick,
                                 example,
@@ -115,15 +98,47 @@ const ExampleText = (props: Props): JSX.Element => {
                               }),
                             }
                           : {
-                              searchResults,
                               subrule,
-                              toModify: parseLink({
+                              exampleText: parseLink({
                                 routerValues,
                                 onLinkClick,
                                 example,
                                 subrule,
                                 searchResults,
                                 allChaptersN,
+                              }),
+                            }
+                      )
+                    : modifyExampleText(
+                        rule
+                          ? {
+                              rule,
+                              exampleText: modifySearchRules({
+                                searchResults,
+                                rule,
+                                toModify: parseLink({
+                                  routerValues,
+                                  onLinkClick,
+                                  example,
+                                  rule,
+                                  searchResults,
+                                  allChaptersN,
+                                }),
+                              }),
+                            }
+                          : {
+                              subrule,
+                              exampleText: modifySearchRules({
+                                searchResults,
+                                subrule,
+                                toModify: parseLink({
+                                  routerValues,
+                                  onLinkClick,
+                                  example,
+                                  subrule,
+                                  searchResults,
+                                  allChaptersN,
+                                }),
                               }),
                             }
                       )}

--- a/app/components/TocChapterList.tsx
+++ b/app/components/TocChapterList.tsx
@@ -12,7 +12,6 @@ interface Props {
 
 const TocChapterList = (props: Props): JSX.Element => {
   const { chapters, sectionNumber, toc, onLinkClick, tocTitleRef } = props;
-//   console.log(sectionNumber, toc, chapters, )
 
   const chapterSubset = chapters.filter(
     (chapter) => chapter.sectionNumber === sectionNumber

--- a/app/components/TocChapterList.tsx
+++ b/app/components/TocChapterList.tsx
@@ -12,6 +12,7 @@ interface Props {
 
 const TocChapterList = (props: Props): JSX.Element => {
   const { chapters, sectionNumber, toc, onLinkClick, tocTitleRef } = props;
+//   console.log(sectionNumber, toc, chapters, )
 
   const chapterSubset = chapters.filter(
     (chapter) => chapter.sectionNumber === sectionNumber

--- a/app/hooks/useSearch.ts
+++ b/app/hooks/useSearch.ts
@@ -40,6 +40,7 @@ const useSearch = (props: SearchData): SearchResults => {
         termRegex.test(subruleNode.text) ||
         (subruleNode.example.length ? checkExamples(subruleNode.example) : 0)
     );
+
     const subruleRules: number[][] = subrulesResult.map((subrule) => [
       subrule.chapterNumber,
       subrule.ruleNumber,
@@ -91,6 +92,7 @@ const useSearch = (props: SearchData): SearchResults => {
       ),
       "sectionNumber"
     );
+
     const ruleChapters: Chapter[] = uniqBy(
       ruleValues.map((val) =>
         chapters.find((chapter) => chapter.chapterNumber === val[1])

--- a/app/typing/types.ts
+++ b/app/typing/types.ts
@@ -143,6 +143,12 @@ export interface ModifyArgs {
   toModify: string | ReactNodeArray;
 }
 
+export interface ExampleModifyArgs {
+  exampleText: string | ReactNodeArray;
+  rule?: Rule;
+  subrule?: Subrule;
+}
+
 export interface RadioCheck {
   partial: boolean;
   exact: boolean;

--- a/app/typing/types.ts
+++ b/app/typing/types.ts
@@ -136,7 +136,7 @@ export interface SearchResults {
   searchResult: number;
 }
 
-export interface ModifyArgs {
+export interface SearchModifyArgs {
   searchResults: SearchResults;
   rule?: Rule;
   subrule?: Subrule;

--- a/app/utils/modify-example-text.tsx
+++ b/app/utils/modify-example-text.tsx
@@ -1,0 +1,38 @@
+import { ReactNodeArray } from "react";
+import reactStringReplace from "react-string-replace";
+import { ExampleModifyArgs } from "../typing/types";
+
+const wrapExampleText = (args: ExampleModifyArgs): string | ReactNodeArray => {
+  const { exampleText, rule, subrule } = args;
+
+  return reactStringReplace(
+    exampleText,
+    "Example:",
+    (match: string, i: number, offset: number) => (
+      <span
+        key={
+          rule
+            ? `${exampleText}.${rule.chapterNumber}-${rule.ruleNumber}-${i}${offset}`
+            : `${exampleText}.${subrule.chapterNumber}-${subrule.ruleNumber}-${subrule.ruleNumber}${subrule.subruleLetter}-${i}${offset}`
+        }
+        className={"exampleEmphasis"}
+      >
+        <em>{match}</em>
+      </span>
+    )
+  );
+};
+
+const modifyExampleText = (
+  args: ExampleModifyArgs
+): string | ReactNodeArray => {
+  // Deconstruct args
+  const { exampleText, rule, subrule } = args;
+
+  // Modify
+  return rule
+    ? wrapExampleText({ exampleText, rule })
+    : wrapExampleText({ exampleText, subrule });
+};
+
+export default modifyExampleText;

--- a/app/utils/modify-example-text.tsx
+++ b/app/utils/modify-example-text.tsx
@@ -12,8 +12,8 @@ const wrapExampleText = (args: ExampleModifyArgs): string | ReactNodeArray => {
       <span
         key={
           rule
-            ? `${exampleText}.${rule.chapterNumber}-${rule.ruleNumber}-${i}${offset}`
-            : `${exampleText}.${subrule.chapterNumber}-${subrule.ruleNumber}-${subrule.ruleNumber}${subrule.subruleLetter}-${i}${offset}`
+            ? `example.${rule.chapterNumber}-${rule.ruleNumber}-${i}${offset}`
+            : `example.${subrule.chapterNumber}-${subrule.ruleNumber}-${subrule.ruleNumber}${subrule.subruleLetter}-${i}${offset}`
         }
         className={"exampleEmphasis"}
       >

--- a/app/utils/modify-search-rules.tsx
+++ b/app/utils/modify-search-rules.tsx
@@ -1,8 +1,8 @@
 import { ReactNodeArray } from "react";
 import reactStringReplace from "react-string-replace";
-import { ModifyArgs } from "../typing/types";
+import { SearchModifyArgs } from "../typing/types";
 
-const wrapSearchTerm = (args: ModifyArgs): string | ReactNodeArray => {
+const wrapSearchTerm = (args: SearchModifyArgs): string | ReactNodeArray => {
   const { searchResults, rule, subrule, toModify } = args;
   const { searchTerm, searchType } = searchResults;
 
@@ -31,7 +31,7 @@ const wrapSearchTerm = (args: ModifyArgs): string | ReactNodeArray => {
   );
 };
 
-const modifySearchRules = (args: ModifyArgs): string | ReactNodeArray => {
+const modifySearchRules = (args: SearchModifyArgs): string | ReactNodeArray => {
   // Deconstruct args
   const { searchResults, rule, subrule, toModify } = args;
 

--- a/app/utils/parse-nodes.ts
+++ b/app/utils/parse-nodes.ts
@@ -21,17 +21,16 @@ const parseNodes = async (rawText: string, i = 0): Promise<RulesParse> => {
       const parser = new Parser();
 
       // Regex
-      const sectionRegex =
-        /(?<=\n)(\d{1})\.\s([a-z\s,:;.]*)(?=\r\n\r\n|\r\r)/gim;
+      const sectionRegex = /(?<=\n)(\d{1})\.\s([a-z\s\W]*)(?=\r\n\r\n|\r\r)/gim;
 
       const chapterRegex =
-        /(?<=\n|\r)(\d{3})\.\s([a-z\s.,:-;]*)(?=\r\n\r\n|\r\r)/gim;
+        /(?<=\n|\r)(\d{3})\.\s([a-z\s\W]*)(?=\r\n\r\n|\r\r)/gim;
 
       const ruleRegex =
-        /(?<=\n|\r)(\d{3})\.(\d{1,3})\.\s([âûáú‘’\da-z\s,:\-;()+—™*[\]{}®.&"“”/'–\\]*?)(?=\r\n\r\n|\r\r)/gim;
+        /(?<=\n|\r)(\d{3})\.(\d{1,3})\.\s([\w\s\W]*?)(?=\r\n\r\n|\r\r)/gim;
 
       const subruleRegex =
-        /(?<=\n|\r)(\d{3})\.(\d{1,3})([a-z]+)\s([âûáú‘’\da-z\s,:\-;()+—™*[\]{}®.&"“”/'–\\]*?)(?=\r\n\r|\r\r)/gim;
+        /(?<=\n|\r)(\d{3})\.(\d{1,3})([a-z]+)\s([\w\s\W]*?)(?=\r\n\r|\r\r)/gim;
 
       // Add rules
       parser.addRule(sectionRegex, (match, section, txt) => {


### PR DESCRIPTION
- Emphasized the "Example:" in example text
- Made parseNode regex more generic