### PR TITLE
Spinner & tocScrolling changes

### DIFF
--- a/app/components/TocSections.tsx
+++ b/app/components/TocSections.tsx
@@ -1,4 +1,5 @@
 import { useRef, MutableRefObject, useEffect, useState } from "react";
+import { Spinner } from "react-bootstrap";
 import TocChapterList from "./TocChapterList";
 import TopSectionWrapper from "./TopSectionWrapper";
 import objectArrayComparison from "../utils/object-array-comparison";
@@ -94,7 +95,7 @@ const TocSections = (props: Props): JSX.Element => {
 
   return (
     <div>
-      {leftViewportRef && (
+      {!!leftViewportRef && !!sections.length && (
         <TopSectionWrapper
           leftViewportRef={leftViewportRef}
           divArray={divArray}
@@ -103,29 +104,42 @@ const TocSections = (props: Props): JSX.Element => {
           setScrolledToSection={setScrolledToSection}
         />
       )}
-      {sections.map((section, i) => (
-        <div
-          // eslint-disable-next-line no-return-assign
-          ref={(el) => (tocSectionListRefs.current[i] = el)}
-          className={styles.tocSectionContainer}
-          key={`s${section.sectionNumber}`}
-        >
-          <span
-            className={styles.tocSectionCard}
+      {sections.length ? (
+        sections.map((section, i) => (
+          <div
             // eslint-disable-next-line no-return-assign
-            ref={(el) => (sectionCardRefs.current[i] = el)}
+            ref={(el) => (tocSectionListRefs.current[i] = el)}
+            className={styles.tocSectionContainer}
+            key={`s${section.sectionNumber}`}
           >
-            {`${section.sectionNumber}. ${section.text}`}
-          </span>
-          <TocChapterList
-            sectionNumber={section.sectionNumber}
-            chapters={chapters}
-            toc={1}
-            onLinkClick={onLinkClick}
-            tocTitleRef={tocTitleRef}
-          />
+            <span
+              className={styles.tocSectionCard}
+              // eslint-disable-next-line no-return-assign
+              ref={(el) => (sectionCardRefs.current[i] = el)}
+            >
+              {`${section.sectionNumber}. ${section.text}`}
+            </span>
+            <TocChapterList
+              sectionNumber={section.sectionNumber}
+              chapters={chapters}
+              toc={1}
+              onLinkClick={onLinkClick}
+              tocTitleRef={tocTitleRef}
+            />
+          </div>
+        ))
+      ) : (
+        <div className={styles.spinnerDiv}>
+          <Spinner
+            animation="border"
+            role="status"
+            variant="dark"
+            className={styles.spinnerComponent}
+          >
+            <span className={styles.loadingText}></span>
+          </Spinner>
         </div>
-      ))}
+      )}
     </div>
   );
 };

--- a/app/styles/TocSections.module.scss
+++ b/app/styles/TocSections.module.scss
@@ -12,3 +12,15 @@
   width: 100%;
   z-index: 9999;
 }
+
+.spinnerDiv {
+  position: relative;
+  width: 25vw;
+  height: 100vh;
+}
+  
+.spinnerComponent {
+  position: fixed;
+  left: 12%;
+  top: 50%;
+}

--- a/pages/rules/[year]/[version].tsx
+++ b/pages/rules/[year]/[version].tsx
@@ -118,7 +118,7 @@ const RuleSetPage = (props: DynamicProps): JSX.Element => {
   const [rules, setRules] = useState<Rule[]>([]);
   const [subrules, setSubrules] = useState<Subrule[]>([]);
 
-  // Save parsed node data to state at init
+  // Save parsed node data to state at init or when a node array changes
   useEffect(() => {
     if (nodes) {
       console.log(nodes);
@@ -264,9 +264,12 @@ const RuleSetPage = (props: DynamicProps): JSX.Element => {
 
   // Scroll ToC to chapterTitle corresponding to url hash value
   const scrollToc = (chapterNumber: number) => {
-    const re = new RegExp(`(${chapterNumber})`);
-    const element = tocRefs.current.find((elem) => re.test(elem.innerText));
-    element.scrollIntoView();
+    // Jumps to chapterNumber 1 less, so don't jump to ~ 100 as there is no 99
+    if (chapterNumber % 100 !== 0) {
+      const re = new RegExp(`(${chapterNumber - 1})`);
+      const element = tocRefs.current.find((elem) => re.test(elem.innerText));
+      element.scrollIntoView();
+    }
   };
 
   // Prop used by TopRuleWrapper to save useTopRule callback value


### PR DESCRIPTION
- Added a spinner to tocSections on load
- tocScrolling no longer scrolls to the first chapter in a section
- tocScrolling now scrolls to the chapter before the url hash value