### PR TITLE
Replace url links

### DIFF
--- a/app/components/SearchForm.tsx
+++ b/app/components/SearchForm.tsx
@@ -275,14 +275,14 @@ const SearchForm = (props: Props): JSX.Element => {
           >
             <FontAwesomeIcon icon={faTimes} />
           </button>
+          <button
+            className="btn btn-primary"
+            id={styles.searchFormButton}
+            type="submit"
+          >
+            <FontAwesomeIcon icon={faSearch} />
+          </button>
         </div>
-        <button
-          className="btn btn-primary"
-          id={styles.searchFormButton}
-          type="submit"
-        >
-          <FontAwesomeIcon icon={faSearch} />
-        </button>
       </div>
       <div className={styles.radiosContainer}>
         <SearchRadio

--- a/app/styles/SearchForm.module.scss
+++ b/app/styles/SearchForm.module.scss
@@ -31,7 +31,10 @@
 }
 
 #searchFormButton {
+  position: absolute;
+  right: -7%;
   width: 7%;
+  height: 42px;
   @include button;
   &:focus {
     box-shadow: none;
@@ -48,5 +51,6 @@
 .inputContainer {
   display: flex;
   width: 84%;
+  height: 42px;
   margin-left: 10%;
 }

--- a/app/styles/globals.scss
+++ b/app/styles/globals.scss
@@ -41,7 +41,7 @@ a.nav-link {
   }
 }
 
-.ruleLink {
+.ruleLink, .urlRuleLink {
   color: $color1;
   opacity: .8;
   &:hover {
@@ -49,7 +49,7 @@ a.nav-link {
   }
 }
 
-.subruleLink {
+.subruleLink, .urlSubruleLink {
   color: $color0;
   opacity: .8;
   &:hover {

--- a/app/typing/types.ts
+++ b/app/typing/types.ts
@@ -136,6 +136,12 @@ export interface ParseAnchorLinks {
   subrule?: Subrule;
 }
 
+export interface ReplaceUrlLinksArgs {
+  rule?: Rule;
+  subrule?: Subrule;
+  toModify: string | ReactNodeArray;
+}
+
 export interface ReplaceTextArgs {
   allChaptersN: string[];
   example?: string;

--- a/app/utils/parse-nodes.ts
+++ b/app/utils/parse-nodes.ts
@@ -10,123 +10,115 @@ import {
   Subrule,
 } from "../typing/types";
 
-const parseNodes = async (rawText: string, i = 0): Promise<RulesParse> => {
-  // Retry 3 times
-  if (i < 4) {
-    try {
-      // Remove extra text
-      const text: string = rawText.split("Glossary")[1];
+const parseNodes = async (rawText: string): Promise<RulesParse> => {
+  try {
+    // Remove extra text
+    const text: string = rawText.split("Glossary")[1];
 
-      // Create parser
-      const parser = new Parser();
+    // Create parser
+    const parser = new Parser();
 
-      // Regex
-      const sectionRegex = /\n(\d{1})\.\s([a-z\s\W]*)(?=\r\n\r\n|\r\r)/gim;
+    // Regex
+    const sectionRegex = /\n(\d{1})\.\s([a-z\s\W]*)(?=\r\n\r\n|\r\r)/gim;
 
-      const chapterRegex = /[\n\r](\d{3})\.\s([a-z\s\W]*)(?=\r\n\r\n|\r\r)/gim;
+    const chapterRegex = /[\n\r](\d{3})\.\s([a-z\s\W]*)(?=\r\n\r\n|\r\r)/gim;
 
-      const ruleRegex =
-        /[\n\r](\d{3})\.(\d{1,3})\.\s([\w\s\W]*?)(?=\r\n\r\n|\r\r)/gim;
+    const ruleRegex =
+      /[\n\r](\d{3})\.(\d{1,3})\.\s([\w\s\W]*?)(?=\r\n\r\n|\r\r)/gim;
 
-      const subruleRegex =
-        /[\n\r](\d{3})\.(\d{1,3})([a-z]+)\s([\w\s\W]*?)(?=\r\n\r|\r\r)/gim;
+    const subruleRegex =
+      /[\n\r](\d{3})\.(\d{1,3})([a-z]+)\s([\w\s\W]*?)(?=\r\n\r|\r\r)/gim;
 
-      // Add rules
-      parser.addRule(sectionRegex, (match, section, txt) => {
-        const sectionNumber = Number(section);
+    // Add rules
+    parser.addRule(sectionRegex, (match, section, txt) => {
+      const sectionNumber = Number(section);
 
-        return { type: "section", text: txt, sectionNumber };
-      });
-      parser.addRule(chapterRegex, (match, chapter, txt) => {
-        const sectionNumber = Number(chapter[0]);
-        const chapterNumber = Number(chapter);
+      return { type: "section", text: txt, sectionNumber };
+    });
+    parser.addRule(chapterRegex, (match, chapter, txt) => {
+      const sectionNumber = Number(chapter[0]);
+      const chapterNumber = Number(chapter);
 
-        return {
-          type: "chapter",
-          text: txt,
-          sectionNumber,
-          chapterNumber,
-        };
-      });
-      parser.addRule(ruleRegex, (match, chapter, rule, txt) => {
-        const sectionNumber = Number(chapter[0]);
-        const chapterNumber = Number(chapter);
-        const ruleNumber = Number(rule);
-        const exampleSearch: string[] = [];
-
-        // Handle text that has examples
-        const textParse: ParseExample = parseExamples(txt);
-
-        return {
-          type: "rule",
-          text: textParse ? textParse.mainText : "",
-          sectionNumber,
-          chapterNumber,
-          ruleNumber,
-          example: textParse ? textParse.exampleTextArray : "",
-          exampleSearch,
-        };
-      });
-      parser.addRule(
-        subruleRegex,
-        (match, chapter, rule, subruleLetter, txt) => {
-          const sectionNumber = Number(chapter[2]);
-          const chapterNumber = Number(chapter);
-          const ruleNumber = Number(rule);
-          const exampleSearch: string[] = [];
-
-          // Handle text that has examples
-          const textParse: ParseExample = parseExamples(txt);
-
-          return {
-            type: "subrule",
-            text: textParse ? textParse.mainText : "",
-            sectionNumber,
-            chapterNumber,
-            ruleNumber,
-            subruleLetter,
-            example: textParse ? textParse.exampleTextArray : "",
-            exampleSearch,
-          };
-        }
-      );
-
-      // Remove all non-matched nodes
-      const tree = parser.toTree(text).filter((node) => node.type !== "text");
-
-      // Filter nodes
-      const sectionNodes: Node[] = sortBy(
-        tree.filter((node) => node.type === "section"),
-        ["sectionNumber"]
-      );
-
-      const chapterNodes: Node[] = sortBy(
-        tree.filter((node) => node.type === "chapter"),
-        ["sectionNumber", "chapterNumber"]
-      );
-
-      const rulesNodes: Node[] = tree.filter((node) => node.type === "rule");
-
-      const subrulesNodes: Node[] = tree.filter(
-        (node) => node.type === "subrule"
-      );
-
-      // Return
       return {
-        sections: sectionNodes as unknown as Section[],
-        chapters: chapterNodes as unknown as Chapter[],
-        rules: rulesNodes as unknown as Rule[],
-        subrules: subrulesNodes as unknown as Subrule[],
+        type: "chapter",
+        text: txt,
+        sectionNumber,
+        chapterNumber,
       };
-    } catch (err) {
-      console.error(err);
+    });
+    parser.addRule(ruleRegex, (match, chapter, rule, txt) => {
+      const sectionNumber = Number(chapter[0]);
+      const chapterNumber = Number(chapter);
+      const ruleNumber = Number(rule);
+      const exampleSearch: string[] = [];
 
-      let val = i;
-      val += 1;
-      parseNodes(rawText, val);
+      // Handle text that has examples
+      const textParse: ParseExample = parseExamples(txt);
+
+      return {
+        type: "rule",
+        text: textParse ? textParse.mainText : "",
+        sectionNumber,
+        chapterNumber,
+        ruleNumber,
+        example: textParse ? textParse.exampleTextArray : "",
+        exampleSearch,
+      };
+    });
+    parser.addRule(subruleRegex, (match, chapter, rule, subruleLetter, txt) => {
+      const sectionNumber = Number(chapter[2]);
+      const chapterNumber = Number(chapter);
+      const ruleNumber = Number(rule);
+      const exampleSearch: string[] = [];
+
+      // Handle text that has examples
+      const textParse: ParseExample = parseExamples(txt);
+
+      return {
+        type: "subrule",
+        text: textParse ? textParse.mainText : "",
+        sectionNumber,
+        chapterNumber,
+        ruleNumber,
+        subruleLetter,
+        example: textParse ? textParse.exampleTextArray : "",
+        exampleSearch,
+      };
+    });
+
+    // Remove all non-matched nodes
+    const tree = parser.toTree(text).filter((node) => node.type !== "text");
+
+    // Filter nodes
+    const sectionNodes: Node[] = sortBy(
+      tree.filter((node) => node.type === "section"),
+      ["sectionNumber"]
+    );
+
+    const chapterNodes: Node[] = sortBy(
+      tree.filter((node) => node.type === "chapter"),
+      ["sectionNumber", "chapterNumber"]
+    );
+
+    const rulesNodes: Node[] = tree.filter((node) => node.type === "rule");
+
+    const subrulesNodes: Node[] = tree.filter(
+      (node) => node.type === "subrule"
+    );
+
+    // Return
+    return {
+      sections: sectionNodes as unknown as Section[],
+      chapters: chapterNodes as unknown as Chapter[],
+      rules: rulesNodes as unknown as Rule[],
+      subrules: subrulesNodes as unknown as Subrule[],
+    };
+  } catch (err) {
+    if (process.env.NODE_ENV !== "production") {
+      console.log(err);
     }
+    return null;
   }
-  return null;
 };
 
 export default parseNodes;

--- a/app/utils/replace-text.ts
+++ b/app/utils/replace-text.ts
@@ -1,7 +1,8 @@
 import { ReactNodeArray } from "react";
 import parseAnchorLinks from "./parse-anchor-links";
-import replaceSearchTerm from "./replace-search-term";
 import replaceExampleText from "./replace-example-text";
+import replaceSearchTerm from "./replace-search-term";
+import replaceUrlLinks from "./replace-url-links";
 import { ReplaceTextArgs } from "../typing/types";
 
 const replaceText = (args: ReplaceTextArgs): ReactNodeArray | string => {
@@ -20,17 +21,7 @@ const replaceText = (args: ReplaceTextArgs): ReactNodeArray | string => {
   if (rule && !example) {
     if (!searchResults.searchTerm) {
       // Rule with no search filter
-      result = parseAnchorLinks({
-        routerValues,
-        onLinkClick,
-        rule,
-        searchResults,
-        allChaptersN,
-      });
-    } else {
-      // Rule with a search filter
-      result = replaceSearchTerm({
-        searchResults,
+      result = replaceUrlLinks({
         rule,
         toModify: parseAnchorLinks({
           routerValues,
@@ -40,21 +31,27 @@ const replaceText = (args: ReplaceTextArgs): ReactNodeArray | string => {
           allChaptersN,
         }),
       });
+    } else {
+      // Rule with a search filter
+      result = replaceUrlLinks({
+        rule,
+        toModify: replaceSearchTerm({
+          searchResults,
+          rule,
+          toModify: parseAnchorLinks({
+            routerValues,
+            onLinkClick,
+            rule,
+            searchResults,
+            allChaptersN,
+          }),
+        }),
+      });
     }
   } else if (subrule && !example) {
     if (!searchResults.searchTerm) {
       // Subrule with no search filter
-      result = parseAnchorLinks({
-        routerValues,
-        onLinkClick,
-        subrule,
-        searchResults,
-        allChaptersN,
-      });
-    } else {
-      // Subrule with a search filter
-      result = replaceSearchTerm({
-        searchResults,
+      result = replaceUrlLinks({
         subrule,
         toModify: parseAnchorLinks({
           routerValues,
@@ -62,6 +59,22 @@ const replaceText = (args: ReplaceTextArgs): ReactNodeArray | string => {
           subrule,
           searchResults,
           allChaptersN,
+        }),
+      });
+    } else {
+      // Subrule with a search filter
+      result = replaceUrlLinks({
+        subrule,
+        toModify: replaceSearchTerm({
+          searchResults,
+          subrule,
+          toModify: parseAnchorLinks({
+            routerValues,
+            onLinkClick,
+            subrule,
+            searchResults,
+            allChaptersN,
+          }),
         }),
       });
     }
@@ -72,35 +85,7 @@ const replaceText = (args: ReplaceTextArgs): ReactNodeArray | string => {
         rule
           ? {
               rule,
-              exampleText: parseAnchorLinks({
-                routerValues,
-                onLinkClick,
-                example,
-                rule,
-                searchResults,
-                allChaptersN,
-              }),
-            }
-          : {
-              subrule,
-              exampleText: parseAnchorLinks({
-                routerValues,
-                onLinkClick,
-                example,
-                subrule,
-                searchResults,
-                allChaptersN,
-              }),
-            }
-      );
-    } else {
-      // Emphasize example text with a search filter
-      result = replaceExampleText(
-        rule
-          ? {
-              rule,
-              exampleText: replaceSearchTerm({
-                searchResults,
+              exampleText: replaceUrlLinks({
                 rule,
                 toModify: parseAnchorLinks({
                   routerValues,
@@ -114,8 +99,7 @@ const replaceText = (args: ReplaceTextArgs): ReactNodeArray | string => {
             }
           : {
               subrule,
-              exampleText: replaceSearchTerm({
-                searchResults,
+              exampleText: replaceUrlLinks({
                 subrule,
                 toModify: parseAnchorLinks({
                   routerValues,
@@ -124,6 +108,47 @@ const replaceText = (args: ReplaceTextArgs): ReactNodeArray | string => {
                   subrule,
                   searchResults,
                   allChaptersN,
+                }),
+              }),
+            }
+      );
+    } else {
+      // Emphasize example text with a search filter
+      result = replaceExampleText(
+        rule
+          ? {
+              rule,
+              exampleText: replaceSearchTerm({
+                searchResults,
+                rule,
+                toModify: replaceUrlLinks({
+                  rule,
+                  toModify: parseAnchorLinks({
+                    routerValues,
+                    onLinkClick,
+                    example,
+                    rule,
+                    searchResults,
+                    allChaptersN,
+                  }),
+                }),
+              }),
+            }
+          : {
+              subrule,
+              exampleText: replaceSearchTerm({
+                searchResults,
+                subrule,
+                toModify: replaceUrlLinks({
+                  subrule,
+                  toModify: parseAnchorLinks({
+                    routerValues,
+                    onLinkClick,
+                    example,
+                    subrule,
+                    searchResults,
+                    allChaptersN,
+                  }),
                 }),
               }),
             }

--- a/app/utils/replace-url-links.tsx
+++ b/app/utils/replace-url-links.tsx
@@ -1,0 +1,52 @@
+import { ReactNodeArray } from "react";
+import Link from "next/link";
+import reactStringReplace from "react-string-replace";
+import { ReplaceUrlLinksArgs } from "../typing/types";
+
+const wrapUrlLinks = (args: ReplaceUrlLinksArgs): ReactNodeArray | string => {
+  // Deconstruct args
+  const { rule, subrule, toModify } = args;
+
+  // Regex
+  const re = /([\w]+\.[\w]+\.[\w/-]+|[\w]+\.[\w/-]+)/;
+
+  return reactStringReplace(
+    toModify,
+    re,
+    (match: string, i: number, offset: number) => {
+      return match.length < 8 ? (
+        // Return match if it's too short to be a url
+        match
+      ) : (
+        <Link
+          href={`https://${match}`}
+          passHref
+          key={
+            rule
+              ? `${rule.chapterNumber}-${rule.ruleNumber}-${i}${offset}`
+              : `${subrule.chapterNumber}-${subrule.ruleNumber}-${subrule.ruleNumber}${subrule.subruleLetter}-${i}${offset}`
+          }
+        >
+          <a target="_blank" rel="noopener noreferrer">
+            <span className={rule ? "urlRuleLink" : "urlSubruleLink"}>
+              <em>{match}</em>
+            </span>
+          </a>
+        </Link>
+      );
+    }
+  );
+};
+const replaceUrlLinks = (
+  args: ReplaceUrlLinksArgs
+): ReactNodeArray | string => {
+  // Deconstruct args
+  const { rule, subrule, toModify } = args;
+
+  // Modify
+  return rule
+    ? wrapUrlLinks({ rule, toModify })
+    : wrapUrlLinks({ subrule, toModify });
+};
+
+export default replaceUrlLinks;


### PR DESCRIPTION
- Search form styling fix
- parseNodes catch returns null
- url text in the rules viewport is now an active link that opens a new tab