### PR TITLE
useTopRule fix, replaceAnchorLinks regex fix

### DIFF
--- a/app/components/ChapterClicked.tsx
+++ b/app/components/ChapterClicked.tsx
@@ -4,8 +4,10 @@ import { ChapterValues, ClickData } from "../typing/types";
 interface Props {
   chapterValues: ChapterValues;
   clickData: ClickData;
+  paused: number;
   setChapterValues: Dispatch<SetStateAction<ChapterValues>>;
   setClickedData: Dispatch<SetStateAction<ClickData>>;
+  setPaused: Dispatch<SetStateAction<number>>;
   setScrollToc: Dispatch<SetStateAction<number>>;
 }
 
@@ -13,8 +15,10 @@ const ChapterClicked = (props: Props): JSX.Element => {
   const {
     chapterValues,
     clickData,
+    paused,
     setChapterValues,
     setClickedData,
+    setPaused,
     setScrollToc,
   } = props;
   const { chapterN, dataSource } = clickData;
@@ -39,7 +43,17 @@ const ChapterClicked = (props: Props): JSX.Element => {
 
   // Update ChapterValues
   useEffect(() => {
-    if (chapterValues.chapterNumber !== chapterN) {
+    if (
+      chapterValues.chapterNumber !== chapterN &&
+      (source === "prop increase" || source === "prop decrease")
+    ) {
+      // Toggle pause, else get a bad callback value after this is set
+      if (!paused) {
+        setPaused(1);
+        setTimeout(() => {
+          setPaused(0);
+        }, 200);
+      }
       setChapterValues((prevValue) => ({
         ...prevValue,
         chapterNumber: chapterN,
@@ -47,7 +61,14 @@ const ChapterClicked = (props: Props): JSX.Element => {
         source,
       }));
     }
-  }, [chapterN, chapterValues.chapterNumber, setChapterValues, source]);
+  }, [
+    chapterN,
+    chapterValues.chapterNumber,
+    paused,
+    setChapterValues,
+    setPaused,
+    source,
+  ]);
 
   // Reset clickedData
   useEffect(() => {
@@ -59,6 +80,7 @@ const ChapterClicked = (props: Props): JSX.Element => {
     }
   }, [clickData.chapterN, setClickedData]);
 
+  // Don't render
   return null;
 };
 

--- a/app/components/TitleChapterNumber.tsx
+++ b/app/components/TitleChapterNumber.tsx
@@ -18,6 +18,7 @@ import {
 interface Props {
   chaptersInUse: Chapter[];
   chapterValues: ChapterValues;
+  paused: number;
   rootRef: MutableRefObject<HTMLDivElement>;
   rulesRef: MutableRefObject<HTMLDivElement[]>;
   rulesInUse: Rule[];
@@ -32,6 +33,7 @@ const TitleChapterNumber = (props: Props): JSX.Element => {
   const {
     chaptersInUse,
     chapterValues,
+    paused,
     rootRef,
     rulesRef,
     rulesInUse,
@@ -148,14 +150,15 @@ const TitleChapterNumber = (props: Props): JSX.Element => {
 
   // If there was a source other than a callback chapterNumber, then ignore current callback
   useEffect(() => {
-    if (latestRuleChapterNumber && source !== "callback") {
+    // useTopRule callback returns after this, so there must be a pause to wait for the callback value to ignore
+    if (latestRuleChapterNumber && source !== "callback" && !paused) {
       setChapterValues((prevValue) => ({
         ...prevValue,
         source: "callback",
         ignoreCallbackNumber: latestRuleChapterNumber,
       }));
     }
-  }, [latestRuleChapterNumber, setChapterValues, source]);
+  }, [latestRuleChapterNumber, paused, setChapterValues, source]);
 
   // When scrolling, save the chapterNumber from useTopRule callback
   useEffect(() => {

--- a/app/hooks/useTopRule.ts
+++ b/app/hooks/useTopRule.ts
@@ -11,7 +11,9 @@ const useTopRule = (
 
   const callback = useCallback(([entry]) => {
     if (entry.isIntersecting) {
-      console.log(entry);
+      if (process.env.NODE_ENV !== "production") {
+        console.log(entry);
+      }
       setRuleNumber(Number(entry.target.innerText.match(/(\d{3})/g)[0]));
     }
   }, []);

--- a/app/utils/replace-anchor-links.tsx
+++ b/app/utils/replace-anchor-links.tsx
@@ -11,7 +11,7 @@ const replaceAnchorLinks = (args: ReplaceAnchorLinks): ReactNodeArray => {
   let updatedText: ReactNodeArray;
   ruleNumberArray.forEach((ruleNumber, index) => {
     // Single digit is a section, so multiply by 100, else match chapterNumber
-    const chapterValue: number | string = /\b\d(?!\S)/.test(ruleNumber)
+    const chapterValue: number | string = /^\d(?!\S)/.test(ruleNumber)
       ? Number(ruleNumber) * 100
       : ruleNumber;
 

--- a/pages/rules/[year]/[version].tsx
+++ b/pages/rules/[year]/[version].tsx
@@ -15,21 +15,21 @@ import Overview from "../../../app/components/Overview";
 import TabContent from "../../../app/components/TabContent";
 import objectArrayComparison from "../../../app/utils/object-array-comparison";
 import {
+  Chapter,
   ChapterValues,
   ClickData,
-  Section,
-  Chapter,
-  Rule,
-  Subrule,
-  GetStaticPropsResult,
-  ValidateChapter,
   DynamicProps,
-  RulesParse,
-  GetStaticPropsParams,
   GetStaticPathsResult,
+  GetStaticPropsParams,
+  GetStaticPropsResult,
+  Rule,
+  RulesParse,
+  ScrollRules,
   SearchData,
   SearchResults,
-  ScrollRules,
+  Section,
+  Subrule,
+  ValidateChapter,
 } from "../../../app/typing/types";
 import styles from "../../../app/styles/[version].module.scss";
 import RuleScroll from "../../../app/components/RuleScroll";
@@ -125,6 +125,7 @@ const RuleSetPage = (props: DynamicProps): JSX.Element => {
     searchSubrules: [],
     searchResult: 1,
   });
+  const [paused, setPaused] = useState<number>(0);
   const [chapterValues, setChapterValues] = useState<ChapterValues>({
     ignoreCallbackNumber: 0,
     chapterNumber: 0,
@@ -330,8 +331,10 @@ const RuleSetPage = (props: DynamicProps): JSX.Element => {
         <ChapterClicked
           chapterValues={chapterValues}
           clickData={clickData}
+          paused={paused}
           setChapterValues={setChapterValues}
           setClickedData={setClickData}
+          setPaused={setPaused}
           setScrollToc={setScrollToc}
         />
       )}
@@ -347,6 +350,7 @@ const RuleSetPage = (props: DynamicProps): JSX.Element => {
         <TitleChapterNumber
           chaptersInUse={chaptersInUse}
           chapterValues={chapterValues}
+          paused={paused}
           rootRef={rightViewportRef}
           rulesRef={rulesRef}
           rulesInUse={rulesInUse}


### PR DESCRIPTION
- Fixed useTopRule callback setting the wrong chapterTitle. There is now a pause if the toc sets the chapter title. Without the delay the intersection observer callback returns the wrong value, as it detects the rule div above the chapter number desired. In this case that callback return needs to be ignored.
- Fixed replaceAnchorLinks single digit regex