### PR TITLE
Reordered types, props & searching same term with different types

### DIFF
--- a/app/components/SearchForm.tsx
+++ b/app/components/SearchForm.tsx
@@ -1,50 +1,54 @@
 import {
-  useState,
-  useRef,
-  useMemo,
-  useEffect,
-  useCallback,
-  FormEvent,
   ChangeEvent,
-  MouseEvent,
   Dispatch,
-  SetStateAction,
+  FormEvent,
   memo,
+  MouseEvent,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
 } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import SearchRadio from "./SearchRadio";
 import {
-  SearchData,
-  SearchResults,
-  SearchFormValue,
-  Section,
   Chapter,
-  Rule,
-  Subrule,
   RadioCheck,
+  Rule,
+  SearchData,
+  SearchFormValue,
+  SearchResults,
+  Section,
+  Subrule,
 } from "../typing/types";
 import styles from "../styles/SearchForm.module.scss";
 
 interface Props {
-  setSearchData: Dispatch<SetStateAction<SearchData>>;
-  setSearchResults: Dispatch<SetStateAction<SearchResults>>;
-  searchedTerm: string;
-  sections: Section[];
   chapters: Chapter[];
   rules: Rule[];
+  searchResults: SearchResults;
+  sections: Section[];
+  setSearchData: Dispatch<SetStateAction<SearchData>>;
+  setSearchResults: Dispatch<SetStateAction<SearchResults>>;
   subrules: Subrule[];
 }
 
 const SearchForm = (props: Props): JSX.Element => {
+  // Destructure props
   const {
-    setSearchData,
-    setSearchResults,
-    searchedTerm,
-    sections,
     chapters,
     rules,
+    searchResults,
+    sections,
+    setSearchData,
+    setSearchResults,
     subrules,
   } = props;
+
+  const searchedTerm = searchResults.searchTerm;
+  const searchedType = searchResults.searchType;
 
   // Input ref
   const input = useRef<HTMLInputElement>();
@@ -85,9 +89,9 @@ const SearchForm = (props: Props): JSX.Element => {
   // Pass memoized searchValue to dynamic page
   useEffect(() => {
     /* 
-      If a search term is validated, pass it to parent and mark submitted
+      - If a search term is validated, pass it to parent and mark submitted
       OR
-      The form was reset, tell the dynamic page to clear search state
+      - The form was reset, tell the dynamic page to clear search state
     */
     if (memoSearchValue.validated && !memoSearchValue.submitted) {
       if (!memoSearchValue.searchTerm && searchedTerm) {
@@ -95,36 +99,45 @@ const SearchForm = (props: Props): JSX.Element => {
         // Clear dynamic page search data
         setSearchData((prevValue) => ({
           ...prevValue,
-          searchTerm: "",
-          searchCleared: 1,
-          searchCompleted: 0,
-          sections: [],
           chapters: [],
           previousSearchTerm: searchedTerm,
           rules: [],
+          searchCleared: 1,
+          searchCompleted: 0,
+          searchTerm: "",
+          sections: [],
           subrules: [],
         }));
+
         // The user may have searched previously. Clear dynamic page search results
         setSearchResults({
+          searchChapters: [],
+          searchResult: 1,
+          searchRules: [],
+          searchSections: [],
+          searchSubrules: [],
           searchTerm: "",
           searchType: "",
-          searchSections: [],
-          searchChapters: [],
-          searchRules: [],
-          searchSubrules: [],
-          searchResult: 1,
         });
-      } else if (searchedTerm !== memoSearchValue.searchTerm) {
-        // Save search data
+      } else if (
+        searchedType !== memoSearchValue.searchType ||
+        searchedTerm !== memoSearchValue.searchTerm
+      ) {
+        /*
+          - If different search types but same term, do the search
+          - If the same search types but different terms, do the search
+          - If the same types and same term, don't do the search 
+        */
+
         setSearchData((prevValue) => ({
           ...prevValue,
-          searchTerm: memoSearchValue.searchTerm,
-          searchCleared: 0,
-          searchCompleted: 0,
-          searchType: memoSearchValue.searchType,
-          sections,
           chapters,
           rules,
+          searchCleared: 0,
+          searchCompleted: 0,
+          searchTerm: memoSearchValue.searchTerm,
+          searchType: memoSearchValue.searchType,
+          sections,
           subrules,
         }));
       }
@@ -136,13 +149,14 @@ const SearchForm = (props: Props): JSX.Element => {
       }));
     }
   }, [
+    chapters,
     memoSearchValue,
+    rules,
     searchedTerm,
+    searchedType,
+    sections,
     setSearchData,
     setSearchResults,
-    sections,
-    chapters,
-    rules,
     subrules,
   ]);
 
@@ -216,18 +230,20 @@ const SearchForm = (props: Props): JSX.Element => {
         setSearchValue((prevValue) => ({
           ...prevValue,
           searchType: e.target.value,
+          submitted: 0,
+          validated: 0,
         }));
       }
       // Toggle radio button checked
       if (e.target.value === "exact" && !radioCheck.exact) {
         setRadioCheck({
-          partial: false,
           exact: true,
+          partial: false,
         });
       } else if (e.target.value === "partial" && !radioCheck.partial) {
         setRadioCheck({
-          partial: true,
           exact: false,
+          partial: true,
         });
       }
     },
@@ -247,13 +263,13 @@ const SearchForm = (props: Props): JSX.Element => {
       // Toggle radio button checked
       if (s === "partial" && !radioCheck.partial) {
         setRadioCheck({
-          partial: true,
           exact: false,
+          partial: true,
         });
       } else if (s === "exact" && !radioCheck.exact) {
         setRadioCheck({
-          partial: false,
           exact: true,
+          partial: false,
         });
       }
     },

--- a/app/components/TabContent.tsx
+++ b/app/components/TabContent.tsx
@@ -24,13 +24,13 @@ interface Props {
 
 const TabContent = (props: Props): JSX.Element => {
   const {
-    searchResults,
-    sections,
     chapters,
     rules,
-    subrules,
+    searchResults,
+    sections,
     setSearchData,
     setSearchResults,
+    subrules,
   } = props;
 
   // State
@@ -49,18 +49,18 @@ const TabContent = (props: Props): JSX.Element => {
     <div className={styles.tabsContainer}>
       <Tabs
         defaultActiveKey="search"
-        variant="pills"
         onSelect={handleTabSelect}
+        variant="pills"
       >
         <Tab eventKey="search" title="Search Rule Set">
           <div>
             <SearchForm
-              setSearchData={setSearchData}
-              setSearchResults={setSearchResults}
-              searchedTerm={searchResults.searchTerm}
-              sections={sections}
               chapters={chapters}
               rules={rules}
+              searchResults={searchResults}
+              sections={sections}
+              setSearchData={setSearchData}
+              setSearchResults={setSearchResults}
               subrules={subrules}
             />
           </div>

--- a/app/typing/types.ts
+++ b/app/typing/types.ts
@@ -1,11 +1,5 @@
 import { ReactNodeArray } from "react";
 
-export interface Section {
-  sectionNumber: number;
-  text: string;
-  type: string;
-}
-
 export interface Chapter {
   chapterNumber: number;
   sectionNumber: number;
@@ -13,11 +7,166 @@ export interface Chapter {
   type: string;
 }
 
+export interface ChapterValues {
+  anchorValue: number;
+  chapterNumber: number;
+  ignoreCallbackNumber: number;
+  source: string;
+}
+
+export interface ClickData {
+  chapterN: number;
+  dataSource: string;
+}
+
+export interface DynamicProps {
+  effectiveDate: string;
+  nodes: RulesParse;
+}
+
+export interface ErrorData {
+  reason: string;
+  value: number;
+}
+
+export interface GetStaticPathsResult {
+  fallback: boolean;
+  paths: GetStaticPropsParams[];
+}
+
+export interface GetStaticPropsParams {
+  params: RouterValues;
+}
+
+export interface GetStaticPropsResult {
+  notFound?: boolean;
+  props: DynamicProps | Record<string, never>;
+  revalidate?: number;
+}
+
+export interface ParseAnchorLinks {
+  allChaptersN: string[];
+  example?: string;
+  onLinkClick: (chapterNumber: number, dataSource: string) => void;
+  routerValues: RouterValues;
+  rule?: Rule;
+  searchResults: SearchResults;
+  subrule?: Subrule;
+}
+
+export interface ParseExample {
+  exampleTextArray: string[];
+  mainText: string;
+}
+
+export interface RadioCheck {
+  exact: boolean;
+  partial: boolean;
+}
+
+export interface ReplaceAnchorLinks {
+  onLinkClick: (chapterNumber: number, dataSource: string) => void;
+  routerValues: RouterValues;
+  rule?: Rule;
+  ruleNumberArray: string[];
+  subrule?: Subrule;
+  text: string;
+}
+
+export interface ReplaceExampleTextArgs {
+  exampleText: string | ReactNodeArray;
+  rule?: Rule;
+  subrule?: Subrule;
+}
+
+export interface ReplaceSearchTermArgs {
+  rule?: Rule;
+  searchResults: SearchResults;
+  subrule?: Subrule;
+  toModify: string | ReactNodeArray;
+}
+
+export interface ReplaceTextArgs {
+  allChaptersN: string[];
+  example?: string;
+  onLinkClick: (chapterNumber: number, dataSource: string) => void;
+  routerValues: RouterValues;
+  rule?: Rule;
+  searchResults: SearchResults;
+  subrule?: Subrule;
+}
+
+export interface ReplaceUrlLinksArgs {
+  rule?: Rule;
+  subrule?: Subrule;
+  toModify: string | ReactNodeArray;
+}
+
+export interface RouterValues {
+  version: string;
+  year: string;
+}
+
 export interface Rule {
   chapterNumber: number;
   example: string[];
   exampleSearch: string[];
   ruleNumber: number;
+  sectionNumber: number;
+  text: string;
+  type: string;
+}
+
+export interface RuleScrollData {
+  rulesInUse: Rule[];
+  ruleNumbers: HTMLSpanElement[];
+}
+
+export interface RulesParse {
+  chapters: Chapter[];
+  rules: Rule[];
+  sections: Section[];
+  subrules: Subrule[];
+}
+
+export interface ScrollRules {
+  hash: string;
+  previousSearchTerm: string;
+  promptScrollToRule: number;
+  searchTerm: string;
+}
+
+export interface SearchData {
+  chapters: Chapter[];
+  previousSearchTerm: string;
+  previousSearchType: string;
+  rules: Rule[];
+  searchCleared: number;
+  searchCompleted: number;
+  searchTerm: string;
+  searchType: string;
+  sections: Section[];
+  subrules: Subrule[];
+}
+
+export interface SearchFormValue {
+  searchTerm: string;
+  searchType: string;
+  submitted: number;
+  validated: number;
+}
+
+export interface SearchResults {
+  searchChapters: Chapter[];
+  searchResult: number;
+  searchRules: Rule[];
+  searchSections: Section[];
+  searchSubrules: Subrule[];
+  searchTerm: string;
+  searchType: string;
+}
+
+export interface Section {
   sectionNumber: number;
   text: string;
   type: string;
@@ -34,160 +183,12 @@ export interface Subrule {
   type: string;
 }
 
-export interface RouterValues {
-  version: string;
-  year: string;
-}
-
-export interface ChapterValues {
-  anchorValue: number;
-  chapterNumber: number;
-  ignoreCallbackNumber: number;
-  source: string;
-}
-
-export interface ErrorData {
-  reason: string;
-  value: number;
-}
-
-export interface ParseExample {
-  exampleTextArray: string[];
-  mainText: string;
-}
-
-export interface DynamicProps {
-  effectiveDate: string;
-  nodes: RulesParse;
-}
-
-export interface GetStaticPropsResult {
-  notFound?: boolean;
-  props: DynamicProps | Record<string, never>;
-  revalidate?: number;
-}
-
-export interface GetStaticPropsParams {
-  params: RouterValues;
-}
-
-export interface GetStaticPathsResult {
-  fallback: boolean;
-  paths: GetStaticPropsParams[];
+export interface TocScrollData {
+  chaptersInUse: Chapter[];
+  tocDivs: HTMLDivElement[];
 }
 
 export interface ValidateChapter {
   nodes: RulesParse;
   validChapter: Chapter | undefined | boolean;
-}
-
-export interface RulesParse {
-  chapters: Chapter[];
-  rules: Rule[];
-  sections: Section[];
-  subrules: Subrule[];
-}
-
-export interface SearchFormValue {
-  searchTerm: string;
-  searchType: string;
-  submitted: number;
-  validated: number;
-}
-
-export interface SearchData {
-  chapters: Chapter[];
-  previousSearchTerm: string;
-  rules: Rule[];
-  searchCleared: number;
-  searchCompleted: number;
-  searchTerm: string;
-  searchType: string;
-  sections: Section[];
-  subrules: Subrule[];
-}
-
-export interface SearchResults {
-  searchChapters: Chapter[];
-  searchResult: number;
-  searchRules: Rule[];
-  searchSections: Section[];
-  searchSubrules: Subrule[];
-  searchTerm: string;
-  searchType: string;
-}
-
-export interface ReplaceAnchorLinks {
-  onLinkClick: (chapterNumber: number, dataSource: string) => void;
-  routerValues: RouterValues;
-  rule?: Rule;
-  ruleNumberArray: string[];
-  subrule?: Subrule;
-  text: string;
-}
-
-export interface ParseAnchorLinks {
-  allChaptersN: string[];
-  example?: string;
-  onLinkClick: (chapterNumber: number, dataSource: string) => void;
-  routerValues: RouterValues;
-  rule?: Rule;
-  searchResults: SearchResults;
-  subrule?: Subrule;
-}
-
-export interface ReplaceUrlLinksArgs {
-  rule?: Rule;
-  subrule?: Subrule;
-  toModify: string | ReactNodeArray;
-}
-
-export interface ReplaceTextArgs {
-  allChaptersN: string[];
-  example?: string;
-  onLinkClick: (chapterNumber: number, dataSource: string) => void;
-  routerValues: RouterValues;
-  rule?: Rule;
-  searchResults: SearchResults;
-  subrule?: Subrule;
-}
-
-export interface ReplaceSearchTermArgs {
-  rule?: Rule;
-  searchResults: SearchResults;
-  subrule?: Subrule;
-  toModify: string | ReactNodeArray;
-}
-
-export interface ReplaceExampleTextArgs {
-  exampleText: string | ReactNodeArray;
-  rule?: Rule;
-  subrule?: Subrule;
-}
-
-export interface RadioCheck {
-  exact: boolean;
-  partial: boolean;
-}
-
-export interface ClickData {
-  chapterN: number;
-  dataSource: string;
-}
-
-export interface ScrollRules {
-  hash: string;
-  previousSearchTerm: string;
-  promptScrollToRule: number;
-  searchTerm: string;
-}
-
-export interface RuleScrollData {
-  rulesInUse: Rule[];
-  ruleNumbers: HTMLSpanElement[];
-}
-
-export interface TocScrollData {
-  chaptersInUse: Chapter[];
-  tocDivs: HTMLDivElement[];
 }

--- a/pages/rules/[year]/[version].tsx
+++ b/pages/rules/[year]/[version].tsx
@@ -106,14 +106,15 @@ const RuleSetPage = (props: DynamicProps): JSX.Element => {
     dataSource: "",
   });
   const [searchData, setSearchData] = useState<SearchData>({
-    searchTerm: "",
-    searchType: "partial",
-    searchCleared: 0,
-    searchCompleted: 0,
-    sections: [],
     chapters: [],
     previousSearchTerm: "",
+    previousSearchType: "",
     rules: [],
+    searchCleared: 0,
+    searchCompleted: 0,
+    searchTerm: "",
+    searchType: "partial",
+    sections: [],
     subrules: [],
   });
   const [searchResults, setSearchResults] = useState<SearchResults>({


### PR DESCRIPTION
- Reordered types & props
- Search results tracks the previous type
- Can now search same term consecutively if the search type is different